### PR TITLE
feat!: new `CouchbaseLite` API

### DIFF
--- a/packages/cbl/README.md
+++ b/packages/cbl/README.md
@@ -63,7 +63,7 @@ import 'package:cbl/cbl.dart';
 import 'package:cbl_flutter/cbl_flutter.dart';
 
 void initCbl() {
-  CouchbaseLite.initialize(libraries: flutterLibraries());
+  CouchbaseLite.init(libraries: flutterLibraries());
 }
 ```
 

--- a/packages/cbl/example/lib/main.dart
+++ b/packages/cbl/example/lib/main.dart
@@ -13,7 +13,7 @@ Libraries getLibraries() {
 
 Future<void> main() async {
   // The `cbl` package needs to be initialized before it can be used.
-  CouchbaseLite.initialize(libraries: getLibraries());
+  CouchbaseLite.init(libraries: getLibraries());
 
   // Now open a database.
   final db = Database.open(

--- a/packages/cbl/lib/src/couchbase_lite.dart
+++ b/packages/cbl/lib/src/couchbase_lite.dart
@@ -74,11 +74,11 @@ class Libraries {
 class CouchbaseLite {
   static final _initialization = Once<void>(
     rejectMultipleExecutions: true,
-    debugName: 'CouchbaseLite.initialize()',
+    debugName: 'CouchbaseLite.init()',
   );
 
   /// Initializes the `cbl` package.
-  static void initialize({required Libraries libraries}) =>
+  static void init({required Libraries libraries}) =>
       _initialization.execute(() {
         ffi.CBLBindings.initInstance(libraries._toFfi());
         MDelegate.instance = CblMDelegate();

--- a/packages/cbl/lib/src/document/blob.dart
+++ b/packages/cbl/lib/src/document/blob.dart
@@ -10,6 +10,7 @@ import '../fleece/encoder.dart';
 import '../fleece/fleece.dart';
 import '../fleece/fleece.dart' as fl;
 import '../log/logger.dart';
+import '../support/ffi.dart';
 import '../support/native_object.dart';
 import '../support/resource.dart';
 import '../support/streams.dart';
@@ -17,7 +18,7 @@ import '../support/utils.dart';
 import 'common.dart';
 import 'document.dart';
 
-late final _blobBindings = CBLBindings.instance.blobs.blob;
+late final _blobBindings = cblBindings.blobs.blob;
 
 /// Max size of data that will be cached in memory with the [Blob].
 const _maxCachedContentLength = 8 * 1024;
@@ -99,7 +100,7 @@ class BlobImplSetter extends fl.SlotSetter {
       value.native.call((pointer) => _blobBindings.setBlob(slot, pointer));
 }
 
-late final _bindings = CBLBindings.instance.blobs;
+late final _bindings = cblBindings.blobs;
 
 class BlobImpl
     with NativeResourceMixin<CBLBlob>

--- a/packages/cbl/lib/src/document/common.dart
+++ b/packages/cbl/lib/src/document/common.dart
@@ -1,19 +1,18 @@
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:cbl_ffi/cbl_ffi.dart';
-
 import '../database/database.dart';
 import '../fleece/decoder.dart';
 import '../fleece/encoder.dart';
 import '../fleece/fleece.dart' as fl;
 import '../fleece/integration/integration.dart';
+import '../support/ffi.dart';
 import 'array.dart';
 import 'blob.dart';
 import 'dictionary.dart';
 import 'document.dart';
 
-late final _blobBindings = CBLBindings.instance.blobs.blob;
+late final _blobBindings = cblBindings.blobs.blob;
 
 abstract class CblConversions {
   Object? toPlainObject();

--- a/packages/cbl/lib/src/document/document.dart
+++ b/packages/cbl/lib/src/document/document.dart
@@ -8,6 +8,7 @@ import 'package:cbl_ffi/cbl_ffi.dart';
 import '../database/database.dart';
 import '../fleece/fleece.dart' as fl;
 import '../fleece/integration/integration.dart';
+import '../support/ffi.dart';
 import '../support/native_object.dart';
 import '../support/resource.dart';
 import '../support/utils.dart';
@@ -16,8 +17,8 @@ import 'blob.dart';
 import 'dictionary.dart';
 import 'fragment.dart';
 
-late final _documentBindings = CBLBindings.instance.document;
-late final _mutableDocumentBindings = CBLBindings.instance.mutableDocument;
+late final _documentBindings = cblBindings.document;
+late final _mutableDocumentBindings = cblBindings.mutableDocument;
 
 /// A Couchbase Lite document.
 ///

--- a/packages/cbl/lib/src/fleece/containers.dart
+++ b/packages/cbl/lib/src/fleece/containers.dart
@@ -6,6 +6,7 @@ import 'package:cbl_ffi/cbl_ffi.dart';
 import 'package:collection/collection.dart';
 
 import '../errors.dart';
+import '../support/ffi.dart';
 import '../support/native_object.dart';
 import 'encoder.dart';
 import 'slice.dart';
@@ -32,7 +33,7 @@ extension on Iterable<CopyFlag> {
 /// An [Doc] points to (and often owns) Fleece-encoded data and provides access
 /// to its Fleece values.
 class Doc extends FleeceDocObject {
-  static late final _bindings = CBLBindings.instance.fleece.doc;
+  static late final _bindings = cblBindings.fleece.doc;
 
   /// Creates a [Doc] by reading Fleece [data] as encoded by a [FleeceEncoder].
   factory Doc.fromResultData(SliceResult data, FLTrust trust) {
@@ -111,7 +112,7 @@ extension on FLValueType {
 ///   [asDict]. If the value is not of that type, null is returned. (Array and
 ///   Dict are documented fully in their own sections.)
 class Value extends FleeceValueObject<FLValue> {
-  static late final _bindings = CBLBindings.instance.fleece.value;
+  static late final _bindings = cblBindings.fleece.value;
 
   /// Creates a [Value] based on a [pointer] to the the native value.
   ///
@@ -270,7 +271,7 @@ class Value extends FleeceValueObject<FLValue> {
 
 /// A Fleece array.
 class Array extends Value with ListMixin<Value> {
-  static late final _bindings = CBLBindings.instance.fleece.array;
+  static late final _bindings = cblBindings.fleece.array;
 
   /// Creates an [Array] based on a [pointer] to the the native value.
   Array.fromPointer(
@@ -324,7 +325,7 @@ class Array extends Value with ListMixin<Value> {
 }
 
 class MutableArray extends Array {
-  static late final _bindings = CBLBindings.instance.fleece.mutableArray;
+  static late final _bindings = cblBindings.fleece.mutableArray;
 
   /// Creates a [MutableArray] based on a [pointer] to the the native value.
   MutableArray.fromPointer(
@@ -462,7 +463,7 @@ class MutableArray extends Array {
 
 /// A Fleece dictionary.
 class Dict extends Value with MapMixin<String, Value> {
-  static late final _bindings = CBLBindings.instance.fleece.dict;
+  static late final _bindings = cblBindings.fleece.dict;
 
   /// Creates a [Dict] based on a [pointer] to the the native value.
   Dict.fromPointer(
@@ -539,7 +540,7 @@ class _DictKeyIterable extends Iterable<String> {
 
 /// Iterator which iterates over the keys of a [Dict].
 class _DictKeyIterator extends Iterator<String> {
-  static late final _bindings = CBLBindings.instance.fleece.dictIterator;
+  static late final _bindings = cblBindings.fleece.dictIterator;
 
   _DictKeyIterator(this.dict);
 
@@ -576,7 +577,7 @@ class _DictKeyIterator extends Iterator<String> {
 
 /// A mutable Fleece [Dict].
 class MutableDict extends Dict {
-  static late final _bindings = CBLBindings.instance.fleece.mutableDict;
+  static late final _bindings = cblBindings.fleece.mutableDict;
 
   /// Creates a [MutableDict] based on a [pointer] to the the native value.
   MutableDict.fromPointer(
@@ -718,7 +719,7 @@ abstract class SlotSetter {
 }
 
 class _DefaultSlotSetter implements SlotSetter {
-  late final _slotBindings = CBLBindings.instance.fleece.slot;
+  late final _slotBindings = cblBindings.fleece.slot;
 
   @override
   bool canSetValue(Object? value) =>

--- a/packages/cbl/lib/src/fleece/decoder.dart
+++ b/packages/cbl/lib/src/fleece/decoder.dart
@@ -4,9 +4,10 @@ import 'dart:typed_data';
 
 import 'package:cbl_ffi/cbl_ffi.dart';
 
+import '../support/ffi.dart';
 import 'slice.dart';
 
-late final _decoderBinds = CBLBindings.instance.fleece.decoder;
+late final _decoderBinds = cblBindings.fleece.decoder;
 
 /// A cache for strings which are encoded as unique shared strings in Fleece
 /// data.

--- a/packages/cbl/lib/src/fleece/encoder.dart
+++ b/packages/cbl/lib/src/fleece/encoder.dart
@@ -3,10 +3,11 @@ import 'dart:typed_data';
 
 import 'package:cbl_ffi/cbl_ffi.dart';
 
+import '../support/ffi.dart';
 import 'decoder.dart';
 import 'slice.dart';
 
-late final _encoderBinds = CBLBindings.instance.fleece.encoder;
+late final _encoderBinds = cblBindings.fleece.encoder;
 
 /// An encoder, which generates encoded Fleece or JSON data.
 ///

--- a/packages/cbl/lib/src/fleece/slice.dart
+++ b/packages/cbl/lib/src/fleece/slice.dart
@@ -5,7 +5,9 @@ import 'dart:typed_data';
 import 'package:cbl_ffi/cbl_ffi.dart';
 import 'package:ffi/ffi.dart';
 
-late final _sliceBinds = CBLBindings.instance.fleece.slice;
+import '../support/ffi.dart';
+
+late final _sliceBinds = cblBindings.fleece.slice;
 
 /// A contiguous area of native memory, whose livetime is tied to some other
 /// object.

--- a/packages/cbl/lib/src/log/console_logger.dart
+++ b/packages/cbl/lib/src/log/console_logger.dart
@@ -1,5 +1,4 @@
-import 'package:cbl_ffi/cbl_ffi.dart';
-
+import '../support/ffi.dart';
 import 'logger.dart';
 
 /// Logger for writing log messages to the system console.
@@ -14,7 +13,7 @@ abstract class ConsoleLogger {
   set level(LogLevel value);
 }
 
-late final _bindings = CBLBindings.instance.logging;
+late final _bindings = cblBindings.logging;
 
 class ConsoleLoggerImpl extends ConsoleLogger {
   ConsoleLoggerImpl() : super._();

--- a/packages/cbl/lib/src/log/file_logger.dart
+++ b/packages/cbl/lib/src/log/file_logger.dart
@@ -1,5 +1,6 @@
 import 'package:cbl_ffi/cbl_ffi.dart';
 
+import '../support/ffi.dart';
 import 'logger.dart';
 
 /// The configuration for log files.
@@ -114,7 +115,7 @@ abstract class FileLogger {
 
 // === Impl ====================================================================
 
-late final _bindings = CBLBindings.instance.logging;
+late final _bindings = cblBindings.logging;
 
 class FileLoggerImpl extends FileLogger {
   FileLoggerImpl() : super._();

--- a/packages/cbl/lib/src/log/logger.dart
+++ b/packages/cbl/lib/src/log/logger.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:cbl_ffi/cbl_ffi.dart';
 
 import '../support/async_callback.dart';
+import '../support/ffi.dart';
 import '../support/native_object.dart';
 
 /// Subsystems that log information.
@@ -105,7 +106,7 @@ extension LogLevelExt on LogLevel {
   CBLLogLevel toCBLLogLevel() => CBLLogLevel.values[index];
 }
 
-late final _bindings = CBLBindings.instance.logging;
+late final _bindings = cblBindings.logging;
 
 Logger? _logger;
 void Function(List<dynamic>)? _loggerCallback;

--- a/packages/cbl/lib/src/replication/replicator.dart
+++ b/packages/cbl/lib/src/replication/replicator.dart
@@ -9,6 +9,7 @@ import '../document/document.dart';
 import '../errors.dart';
 import '../fleece/fleece.dart' as fl;
 import '../support/async_callback.dart';
+import '../support/ffi.dart';
 import '../support/native_object.dart';
 import '../support/resource.dart';
 import '../support/streams.dart';
@@ -155,7 +156,7 @@ abstract class Replicator implements ClosableResource {
   bool isDocumentPending(String documentId);
 }
 
-late final _bindings = CBLBindings.instance.replicator;
+late final _bindings = cblBindings.replicator;
 
 class ReplicatorImpl
     with ClosableResourceMixin, NativeResourceMixin<CBLReplicator>
@@ -464,7 +465,7 @@ AsyncCallback _wrapConflictResolver(
       // if (resolvedPointer != null &&
       //     resolved != local &&
       //     resolved != remote) {
-      //   CBLBindings.instance.base.retainRefCounted(resolvedPointer.cast());
+      //   cblBindings.base.retainRefCounted(resolvedPointer.cast());
       // }
 
       // Workaround for a bug in CBL C SDK, which frees all resolved
@@ -472,7 +473,7 @@ AsyncCallback _wrapConflictResolver(
       // commented out code block should replace this one.
       // https://github.com/couchbase/couchbase-lite-C/issues/148
       if (resolvedPointer != null) {
-        CBLBindings.instance.base.retainRefCounted(resolvedPointer.cast());
+        cblBindings.base.retainRefCounted(resolvedPointer.cast());
       }
 
       return resolvedPointer?.address;

--- a/packages/cbl/lib/src/support/async_callback.dart
+++ b/packages/cbl/lib/src/support/async_callback.dart
@@ -3,6 +3,7 @@ import 'dart:isolate';
 
 import 'package:cbl_ffi/cbl_ffi.dart';
 
+import 'ffi.dart';
 import 'native_object.dart';
 import 'resource.dart';
 
@@ -11,7 +12,7 @@ import 'resource.dart';
 /// The handler receives a list of [arguments] from native side.
 typedef AsyncCallbackHandler = FutureOr<Object?> Function(List arguments);
 
-late final _bindings = CBLBindings.instance.asyncCallback;
+late final _bindings = cblBindings.asyncCallback;
 
 var _nextId = 0;
 int _generateId() {

--- a/packages/cbl/lib/src/support/debug.dart
+++ b/packages/cbl/lib/src/support/debug.dart
@@ -1,5 +1,4 @@
-import 'package:cbl_ffi/cbl_ffi.dart';
-
+import 'ffi.dart';
 import 'native_object.dart';
 
 /// Setting this flag to `true` enables printing of debug information for
@@ -10,6 +9,6 @@ bool _debugRefCountedObject = false;
 set debugRefCounted(bool value) {
   if (_debugRefCountedObject != value) {
     _debugRefCountedObject = value;
-    CBLBindings.instance.base.debugRefCounted = value;
+    cblBindings.base.debugRefCounted = value;
   }
 }

--- a/packages/cbl/lib/src/support/ffi.dart
+++ b/packages/cbl/lib/src/support/ffi.dart
@@ -1,6 +1,6 @@
 import 'package:cbl_ffi/cbl_ffi.dart';
 
-late final cblBindings = () {
+late final CBLBindings cblBindings = () {
   final bindings = CBLBindings.maybeInstance;
   if (bindings == null) {
     throw StateError(

--- a/packages/cbl/lib/src/support/ffi.dart
+++ b/packages/cbl/lib/src/support/ffi.dart
@@ -1,0 +1,11 @@
+import 'package:cbl_ffi/cbl_ffi.dart';
+
+late final cblBindings = () {
+  final bindings = CBLBindings.maybeInstance;
+  if (bindings == null) {
+    throw StateError(
+      'CouchbaseLite.init must be called before using the cbl library.',
+    );
+  }
+  return bindings;
+}();

--- a/packages/cbl/lib/src/support/native_object.dart
+++ b/packages/cbl/lib/src/support/native_object.dart
@@ -4,6 +4,7 @@ import 'dart:ffi';
 import 'package:cbl_ffi/cbl_ffi.dart';
 
 import '../errors.dart';
+import 'ffi.dart';
 import 'resource.dart';
 
 /// Keeps a [NativeObject] alive while the [Function] [fn] is running.
@@ -136,7 +137,7 @@ class CblObject<T extends NativeType> extends NativeObject<T> {
     bool adopt = true,
     required String? debugName,
   }) : super(pointer) {
-    CBLBindings.instance.base.bindCBLRefCountedToDartObject(
+    cblBindings.base.bindCBLRefCountedToDartObject(
       this,
       pointer.cast(),
       !adopt,
@@ -152,8 +153,7 @@ class CBLReplicatorObject extends NativeObject<CBLReplicator> {
     Pointer<CBLReplicator> pointer, {
     required String? debugName,
   }) : super(pointer) {
-    CBLBindings.instance.replicator
-        .bindReplicatorToDartObject(this, pointer, debugName);
+    cblBindings.replicator.bindReplicatorToDartObject(this, pointer, debugName);
   }
 }
 
@@ -161,7 +161,7 @@ class CBLReplicatorObject extends NativeObject<CBLReplicator> {
 class FleeceDocObject extends NativeObject<FLDoc> {
   /// Creates a handle to a Fleece doc.
   FleeceDocObject(Pointer<FLDoc> pointer) : super(pointer) {
-    CBLBindings.instance.fleece.doc.bindToDartObject(this, pointer);
+    cblBindings.fleece.doc.bindToDartObject(this, pointer);
   }
 }
 
@@ -184,7 +184,7 @@ class FleeceValueObject<T extends NativeType> extends NativeObject<T> {
     );
 
     if (isRefCounted) {
-      CBLBindings.instance.fleece.value.bindToDartObject(
+      cblBindings.fleece.value.bindToDartObject(
         this,
         pointer.cast(),
         !adopt,

--- a/packages/cbl_e2e_tests/lib/src/fleece/integration_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/fleece/integration_test.dart
@@ -11,7 +11,7 @@ void main() {
 
   group('Fleece Integration', () {
     // The previous delegate needs to be restored because
-    // `CouchbaseLite.initialize` is only called once for all tests, which is
+    // `CouchbaseLite.initnly called once for all tests, which is
     // where the MDelegate implementation for CouchbaseList is set up.
     MDelegate? previousDelegate;
 

--- a/packages/cbl_e2e_tests/lib/src/fleece/integration_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/fleece/integration_test.dart
@@ -11,7 +11,7 @@ void main() {
 
   group('Fleece Integration', () {
     // The previous delegate needs to be restored because
-    // `CouchbaseLite.initnly called once for all tests, which is
+    // `CouchbaseLite.init` is only called once for all tests, which is
     // where the MDelegate implementation for CouchbaseList is set up.
     MDelegate? previousDelegate;
 

--- a/packages/cbl_e2e_tests/lib/src/test_binding.dart
+++ b/packages/cbl_e2e_tests/lib/src/test_binding.dart
@@ -74,7 +74,7 @@ abstract class CblE2eTestBinding {
     setUpAllFn(() async {
       tmpDir = await resolveTmpDir();
       await _cleanTestTmpDir();
-      CouchbaseLite.initialize(libraries: libraries);
+      CouchbaseLite.init(libraries: libraries);
     });
   }
 

--- a/packages/cbl_ffi/lib/src/bindings.dart
+++ b/packages/cbl_ffi/lib/src/bindings.dart
@@ -56,6 +56,8 @@ class CBLBindings extends Bindings {
     return instance;
   }
 
+  static CBLBindings? get maybeInstance => _instance;
+
   static void initInstance(Libraries libraries) {
     _instance ??= CBLBindings(
       libraries,

--- a/packages/cbl_flutter/README.md
+++ b/packages/cbl_flutter/README.md
@@ -29,6 +29,6 @@ import 'package:cbl/cbl.dart';
 import 'package:cbl_flutter/cbl_flutter.dart';
 
 void initCbl() {
-  CouchbaseLite.initialize(libraries: flutterLibraries());
+  CouchbaseLite.init(libraries: flutterLibraries());
 }
 ```

--- a/packages/cbl_flutter/example/lib/main.dart
+++ b/packages/cbl_flutter/example/lib/main.dart
@@ -24,7 +24,7 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
-    CouchbaseLite.initialize(libraries: flutterLibraries());
+    CouchbaseLite.init(libraries: flutterLibraries());
 
     _initFuture = _init();
   }


### PR DESCRIPTION
- Rename `CouchbaseLite.initialize` to `init`
- Throw exception when package is used before calling `CouchbaseLite.init`

Closes #100