### PR TITLE
feat: improve `_BlobReadStreamController`

### DIFF
--- a/native/cbl-dart/src/CBL+Dart.cpp
+++ b/native/cbl-dart/src/CBL+Dart.cpp
@@ -574,10 +574,35 @@ CBLDart_FLSliceResult CBLDart_CBLBlob_Content(const CBLBlob *blob,
   return CBLDart_FLSliceResultToDart(CBLBlob_Content(blob, errorOut));
 }
 
-uint64_t CBLDart_CBLBlobReader_Read(CBLBlobReadStream *stream, void *buf,
-                                    uint64_t bufSize, CBLError *outError) {
-  return CBLBlobReader_Read(stream, buf, static_cast<size_t>(bufSize),
-                            outError);
+static void CBLDart_FinalizeCBLBlobReadStream(void *isolate_callback_data,
+                                              void *peer) {
+  CBLBlobReader_Close(reinterpret_cast<CBLBlobReadStream *>(peer));
+}
+
+void CBLDart_BindBlobReadStreamToDartObject(Dart_Handle object,
+                                            CBLBlobReadStream *stream) {
+  Dart_NewFinalizableHandle(object, stream, 0,
+                            CBLDart_FinalizeCBLBlobReadStream);
+}
+
+CBLDart_FLSliceResult CBLDart_CBLBlobReader_Read(CBLBlobReadStream *stream,
+                                                 uint64_t bufferSize,
+                                                 CBLError *outError) {
+  auto bufferSize_t = static_cast<size_t>(bufferSize);
+  auto buffer = FLSliceResult_New(bufferSize_t);
+
+  auto bytesRead = CBLBlobReader_Read(stream, const_cast<void *>(buffer.buf),
+                                      bufferSize_t, outError);
+
+  // Handle error
+  if (bytesRead == -1) {
+    FLSliceResult_Release(buffer);
+    return {nullptr, 0};
+  }
+
+  buffer.size = bytesRead;
+
+  return CBLDart_FLSliceResultToDart(buffer);
 }
 
 CBLBlob *CBLDart_CBLBlob_CreateWithData(CBLDart_FLString contentType,

--- a/native/cbl-dart/src/CBL+Dart.cpp
+++ b/native/cbl-dart/src/CBL+Dart.cpp
@@ -581,8 +581,8 @@ static void CBLDart_FinalizeCBLBlobReadStream(void *isolate_callback_data,
 
 void CBLDart_BindBlobReadStreamToDartObject(Dart_Handle object,
                                             CBLBlobReadStream *stream) {
-  Dart_NewFinalizableHandle(object, stream, 0,
-                            CBLDart_FinalizeCBLBlobReadStream);
+  Dart_NewFinalizableHandle_DL(object, stream, 0,
+                               CBLDart_FinalizeCBLBlobReadStream);
 }
 
 CBLDart_FLSliceResult CBLDart_CBLBlobReader_Read(CBLBlobReadStream *stream,

--- a/native/cbl-dart/src/CBL+Dart.h
+++ b/native/cbl-dart/src/CBL+Dart.h
@@ -244,8 +244,13 @@ CBLDart_FLSliceResult CBLDart_CBLBlob_Content(const CBLBlob *blob,
                                               CBLError *errorOut);
 
 CBLDART_EXPORT
-uint64_t CBLDart_CBLBlobReader_Read(CBLBlobReadStream *stream, void *buf,
-                                    uint64_t bufSize, CBLError *outError);
+void CBLDart_BindBlobReadStreamToDartObject(Dart_Handle object,
+                                            CBLBlobReadStream *stream);
+
+CBLDART_EXPORT
+CBLDart_FLSliceResult CBLDart_CBLBlobReader_Read(CBLBlobReadStream *stream,
+                                                 uint64_t bufferSize,
+                                                 CBLError *outError);
 
 CBLDART_EXPORT
 CBLBlob *CBLDart_CBLBlob_CreateWithData(CBLDart_FLString contentType,

--- a/packages/cbl/lib/src/document/blob.dart
+++ b/packages/cbl/lib/src/document/blob.dart
@@ -317,7 +317,10 @@ class _BlobReadStreamController
 
   final BlobImpl _blob;
 
-  CBLBlobReadStreamObject? _stream;
+  late final _stream = CBLBlobReadStreamObject(
+    _blob.native.call(_bindings.readStream.openContentStream),
+  );
+
   var _isPaused = false;
 
   @override
@@ -332,20 +335,12 @@ class _BlobReadStreamController
   @override
   void onCancel() => _pause();
 
-  void _ensureStreamIsOpen() {
-    _stream ??= CBLBlobReadStreamObject(
-      _blob.native.call(_bindings.readStream.openContentStream),
-    );
-  }
-
   void _start() {
     try {
       _isPaused = false;
 
-      _ensureStreamIsOpen();
-
       while (!_isPaused) {
-        final buffer = _stream!
+        final buffer = _stream
             .call((pointer) =>
                 _bindings.readStream.read(pointer, _readStreamChunkSize))
             ?.let(SliceResult.fromFLSliceResult);

--- a/packages/cbl/lib/src/fleece/slice.dart
+++ b/packages/cbl/lib/src/fleece/slice.dart
@@ -150,9 +150,18 @@ class SliceResult extends Slice {
           ? null
           : SliceResult._(slice.buf, slice.size, retain: retain);
 
+  /// Expando which is used to keep a [SliceResult] alive, while [Uint8List]s
+  /// are alive which are backed by it.
+  static final _backingSliceOfBytes =
+      Expando<SliceResult>('SliceResult.backingSliceOfBytes');
+
   /// Returns an modifiable view of the data of this slice.
   @override
-  Uint8List asBytes() => buf.asTypedList(size);
+  Uint8List asBytes() {
+    final bytes = buf.asTypedList(size);
+    _backingSliceOfBytes[bytes] = this;
+    return bytes;
+  }
 
   @override
   String toString() => 'SliceResult(buf: $buf, size: $size)';

--- a/packages/cbl/lib/src/support/native_object.dart
+++ b/packages/cbl/lib/src/support/native_object.dart
@@ -153,7 +153,14 @@ class CBLReplicatorObject extends NativeObject<CBLReplicator> {
     Pointer<CBLReplicator> pointer, {
     required String? debugName,
   }) : super(pointer) {
-    cblBindings.replicator.bindReplicatorToDartObject(this, pointer, debugName);
+    cblBindings.replicator.bindToDartObject(this, pointer, debugName);
+  }
+}
+
+class CBLBlobReadStreamObject extends NativeObject<CBLBlobReadStream> {
+  /// Creates a handle to a CBLBlobReadStream.
+  CBLBlobReadStreamObject(Pointer<CBLBlobReadStream> pointer) : super(pointer) {
+    cblBindings.blobs.readStream.bindToDartObject(this, pointer);
   }
 }
 

--- a/packages/cbl_ffi/lib/src/base.dart
+++ b/packages/cbl_ffi/lib/src/base.dart
@@ -228,17 +228,19 @@ class CBLErrorException implements Exception {
 
 void checkCBLError({String? errorSource}) {
   if (!globalCBLError.ref.isOk) {
-    if (errorSource == null) {
-      throw CBLErrorException.fromCBLError(
-        globalCBLError,
-      );
-    } else {
-      throw CBLErrorException.fromCBLErrorWithSource(
-        globalCBLError,
-        errorSource: errorSource,
-        errorPosition: globalErrorPosition.value,
-      );
-    }
+    throwCBLError(errorSource: errorSource);
+  }
+}
+
+Never throwCBLError({String? errorSource}) {
+  if (errorSource == null) {
+    throw CBLErrorException.fromCBLError(globalCBLError);
+  } else {
+    throw CBLErrorException.fromCBLErrorWithSource(
+      globalCBLError,
+      errorSource: errorSource,
+      errorPosition: globalErrorPosition.value,
+    );
   }
 }
 

--- a/packages/cbl_ffi/lib/src/replicator.dart
+++ b/packages/cbl_ffi/lib/src/replicator.dart
@@ -606,7 +606,7 @@ class ReplicatorBindings extends Bindings {
     });
   }
 
-  void bindReplicatorToDartObject(
+  void bindToDartObject(
     Object object,
     Pointer<CBLReplicator> replicator,
     String? debugName,


### PR DESCRIPTION
- close stream in dart finalizer
- don't copy read buffer unnecessarily

Closes #47