### PR TITLE
fix: do not stop replicator while it is connecting

### DIFF
--- a/packages/cbl_e2e_tests/lib/src/replication/replicator_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/replication/replicator_test.dart
@@ -36,10 +36,8 @@ void main() {
             ConflictResolver.from((conflict) => conflict.localDocument),
       ));
 
+      // Check that is possible to start the replicator with this configuration.
       await repl.start();
-
-      await preReplicatorStopDelay();
-
       await repl.close();
     });
 

--- a/packages/cbl_e2e_tests/lib/src/utils/replicator_utils.dart
+++ b/packages/cbl_e2e_tests/lib/src/utils/replicator_utils.dart
@@ -1,19 +1,10 @@
 import 'dart:async';
 
 import 'package:cbl/cbl.dart';
-import 'package:cbl/src/support/utils.dart';
 
 import '../test_binding.dart';
 
 final testSyncGatewayUrl = Uri.parse('ws://localhost:4984/db');
-
-/// Delay to wait before stopping a [Replicator] to prevent it from crashing.
-///
-/// If a [Replicator] is stopped shortly after starting it is possible that
-/// it makes a connection to the server after it was stopped, causing a crash.
-/// This is a bug in Couchbase Lite.
-Future<void> preReplicatorStopDelay() =>
-    Future<void>.delayed(const Duration(milliseconds: 500));
 
 extension ReplicatorUtilsDatabaseExtension on Database {
   /// Creates a replicator which is configured with the test sync gateway
@@ -39,15 +30,7 @@ extension ReplicatorUtilsDatabaseExtension on Database {
         conflictResolver: conflictResolver != null
             ? ConflictResolver.from(conflictResolver)
             : null,
-      )).then((replicator) {
-        addTearDown(() async {
-          /// Ensures that when the replicator is closed as part of closing the
-          /// database it wont be stopped to quickly.
-          await preReplicatorStopDelay();
-          return replicator.stop();
-        });
-        return replicator;
-      });
+      ));
 }
 
 final isReplicatorStatus = isA<ReplicatorStatus>();

--- a/packages/cbl_e2e_tests/lib/src/utils/test_document.dart
+++ b/packages/cbl_e2e_tests/lib/src/utils/test_document.dart
@@ -19,7 +19,7 @@ void setupTestDocument() {
 /// [testDocumentId] which has [value] in its properties.
 Matcher isTestDocument(String value) => isA<Document>()
     .having((it) => it.id, 'id', testDocumentId)
-    .having((it) => it.toPlainMap(), 'toMap()', {'value': value});
+    .having((it) => it.toPlainMap(), 'toPlainMap()', {'value': value});
 
 extension TestDocumentDatabaseExtension on Database {
   /// Writes [value] in the properties of the test document. If its does not


### PR DESCRIPTION
Workaround for a bug in Couchbase Lite which can cause a crash when stopping a replicator while it is connecting.