### PR TITLE
feat: add `toJson` methods to containers

### DIFF
--- a/packages/cbl/lib/src/document/array.dart
+++ b/packages/cbl/lib/src/document/array.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 import 'dart:collection';
 
+import 'package:cbl_ffi/cbl_ffi.dart';
 import 'package:collection/collection.dart';
 
 import '../fleece/fleece.dart';
@@ -100,6 +101,9 @@ abstract class ArrayInterface implements ArrayFragment {
 abstract class Array implements ArrayInterface, Iterable<Object?> {
   /// Returns a mutable copy of this array.
   MutableArray toMutable();
+
+  /// Returns this array's data as JSON.
+  String toJson();
 }
 
 /// Defines a set of methods for getting and setting array data.
@@ -365,6 +369,14 @@ class ArrayImpl
   @override
   MutableArray toMutable() =>
       MutableArrayImpl(MArray.asCopy(_array, isMutable: true));
+
+  @override
+  String toJson() {
+    final encoder = FleeceEncoder(format: FLEncoderFormat.json);
+    final done = encodeTo(encoder);
+    assert(done is! Future);
+    return encoder.finish().toDartString();
+  }
 
   @override
   MCollection get mCollection => _array;

--- a/packages/cbl/lib/src/document/dictionary.dart
+++ b/packages/cbl/lib/src/document/dictionary.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 import 'dart:collection';
 
+import 'package:cbl_ffi/cbl_ffi.dart';
 import 'package:collection/collection.dart';
 
 import '../fleece/encoder.dart';
@@ -92,6 +93,9 @@ abstract class DictionaryInterface implements DictionaryFragment {
 abstract class Dictionary implements DictionaryInterface, Iterable<String> {
   /// Returns a mutable copy of this dictionary.
   MutableDictionary toMutable();
+
+  /// Returns this dictionary's data as JSON.
+  String toJson();
 }
 
 /// Defines a set of methods for getting and setting dictionary data.
@@ -230,6 +234,14 @@ class DictionaryImpl
   @override
   MutableDictionary toMutable() =>
       MutableDictionaryImpl(MDict.asCopy(_dict, isMutable: true));
+
+  @override
+  String toJson() {
+    final encoder = FleeceEncoder(format: FLEncoderFormat.json);
+    final done = encodeTo(encoder);
+    assert(done is! Future);
+    return encoder.finish().toDartString();
+  }
 
   @override
   MCollection get mCollection => _dict;

--- a/packages/cbl/lib/src/document/document.dart
+++ b/packages/cbl/lib/src/document/document.dart
@@ -35,6 +35,9 @@ abstract class Document implements DictionaryInterface, Iterable<String> {
 
   /// Returns a mutable copy of the document.
   MutableDocument toMutable();
+
+  /// Returns this document's properties as JSON.
+  String toJson();
 }
 
 /// A mutable version of [Document].
@@ -257,6 +260,9 @@ class DelegateDocument with IterableMixin<String> implements Document {
         delegate.toMutable(),
         database: _database,
       );
+
+  @override
+  String toJson() => _properties.toJson();
 
   @override
   Iterator<String> get iterator => _properties.iterator;

--- a/packages/cbl_e2e_tests/lib/src/document/array_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/document/array_test.dart
@@ -1,12 +1,10 @@
-import 'dart:typed_data';
-
 import 'package:cbl/cbl.dart';
 import 'package:cbl/src/document/array.dart';
-import 'package:cbl/src/document/common.dart';
 import 'package:cbl/src/fleece/fleece.dart' as fl;
 import 'package:cbl/src/fleece/integration/integration.dart';
 
 import '../../test_binding_impl.dart';
+import '../fixtures/values.dart';
 import '../test_binding.dart';
 import '../utils/matchers.dart';
 
@@ -50,8 +48,6 @@ void main() {
     });
 
     test('toPlainList', () {
-      final date = DateTime.now();
-      final blob = Blob.fromData('', Uint8List(0));
       final array = immutableArray([
         'x',
         'a',
@@ -59,8 +55,8 @@ void main() {
         .2,
         3,
         true,
-        date,
-        blob,
+        testDate,
+        testBlob,
         <Object?>[],
         <String, Object>{},
       ]);
@@ -71,11 +67,72 @@ void main() {
         .2,
         3,
         true,
-        date.toIso8601String(),
-        blob,
+        testDate.toIso8601String(),
+        testBlob,
         <Object?>[],
         <String, Object?>{},
       ]);
+    });
+
+    test('toJson', () {
+      expect(immutableArray().toJson(), '[]');
+      expect(
+        immutableArray([
+          null,
+          'a',
+          1,
+          .2,
+          true,
+          testDate,
+          testBlob,
+          <Object?>[],
+          <String, Object?>{},
+        ]).toJson(),
+        json(
+          '''
+          [
+            null,
+            "a",
+            1,
+            0.2,
+            true,
+            "${testDate.toIso8601String()}",
+            ${testBlob.toJson()},
+            [],
+            {}
+          ]
+          ''',
+        ),
+      );
+      expect(MutableArray().toJson(), '[]');
+      expect(
+        MutableArray([
+          null,
+          'a',
+          1,
+          .2,
+          true,
+          testDate,
+          testBlob,
+          <Object?>[],
+          <String, Object?>{},
+        ]).toJson(),
+        json(
+          '''
+          [
+            null,
+            "a",
+            1,
+            0.2,
+            true,
+            "${testDate.toIso8601String()}",
+            ${testBlob.toJson()},
+            [],
+            {}
+          ]
+          ''',
+        ),
+      );
     });
 
     test('iterable', () {
@@ -85,8 +142,6 @@ void main() {
     });
 
     test('get value with matching typed getter', () {
-      final date = DateTime.now();
-      final blob = Blob.fromData('', Uint8List(0));
       final array = immutableArray([
         'x',
         'a',
@@ -94,8 +149,8 @@ void main() {
         .2,
         3,
         true,
-        date,
-        blob,
+        testDate,
+        testBlob,
         <Object?>[],
         <String, Object>{},
       ]);
@@ -106,8 +161,8 @@ void main() {
       expect(array.float(3), .2);
       expect(array.number(4), 3);
       expect(array.boolean(5), true);
-      expect(array.date(6), date);
-      expect(array.blob(7), blob);
+      expect(array.date(6), testDate);
+      expect(array.blob(7), testBlob);
       expect(array.array(8), MutableArray());
       expect(array.dictionary(9), MutableDictionary());
     });
@@ -183,11 +238,10 @@ void main() {
         expect(array.value(0), 3);
         array.setBoolean(true, at: 0);
         expect(array.value(0), true);
-        array.setDate(DateTime(0), at: 0);
-        expect(array.date(0), DateTime(0));
-        final blob = Blob.fromData('', Uint8List(0));
-        array.setBlob(blob, at: 0);
-        expect(array.value(0), blob);
+        array.setDate(testDate, at: 0);
+        expect(array.date(0), testDate);
+        array.setBlob(testBlob, at: 0);
+        expect(array.value(0), testBlob);
         array.setArray(MutableArray([true]), at: 0);
         expect(array.value(0), MutableArray([true]));
         array.setDictionary(MutableDictionary({'key': 'value'}), at: 0);
@@ -202,17 +256,14 @@ void main() {
         expect(() => array.setFloat(0, at: 0), throwsRangeError);
         expect(() => array.setNumber(0, at: 0), throwsRangeError);
         expect(() => array.setBoolean(true, at: 0), throwsRangeError);
-        expect(() => array.setDate(DateTime.now(), at: 0), throwsRangeError);
-        expect(() => array.setBlob(Blob.fromData('', Uint8List(0)), at: 0),
-            throwsRangeError);
+        expect(() => array.setDate(testDate, at: 0), throwsRangeError);
+        expect(() => array.setBlob(testBlob, at: 0), throwsRangeError);
         expect(() => array.setArray(MutableArray(), at: 0), throwsRangeError);
         expect(() => array.setDictionary(MutableDictionary(), at: 0),
             throwsRangeError);
       });
 
       test('append values', () {
-        final date = DateTime(0);
-        final blob = Blob.fromData('', Uint8List(0));
         final array = MutableArray()
           ..addValue('x')
           ..addString('a')
@@ -220,8 +271,8 @@ void main() {
           ..addFloat(.2)
           ..addNumber(3)
           ..addBoolean(true)
-          ..addDate(date)
-          ..addBlob(blob)
+          ..addDate(testDate)
+          ..addBlob(testBlob)
           ..addArray(MutableArray([true]))
           ..addDictionary(MutableDictionary({'key': 'value'}));
 
@@ -232,16 +283,14 @@ void main() {
           .2,
           3,
           true,
-          date.toIso8601String(),
-          blob,
+          testDate.toIso8601String(),
+          testBlob,
           [true],
           {'key': 'value'},
         ]);
       });
 
       test('insert values', () {
-        final date = DateTime(0);
-        final blob = Blob.fromData('', Uint8List(0));
         final array = MutableArray()
           ..insertValue('x', at: 0)
           ..insertString('a', at: 0)
@@ -249,16 +298,16 @@ void main() {
           ..insertFloat(.2, at: 0)
           ..insertNumber(3, at: 0)
           ..insertBoolean(true, at: 0)
-          ..insertDate(date, at: 0)
-          ..insertBlob(blob, at: 0)
+          ..insertDate(testDate, at: 0)
+          ..insertBlob(testBlob, at: 0)
           ..insertArray(MutableArray([true]), at: 0)
           ..insertDictionary(MutableDictionary({'key': 'value'}), at: 0);
 
         expect(array.toPlainList(), [
           {'key': 'value'},
           [true],
-          blob,
-          date.toIso8601String(),
+          testBlob,
+          testDate.toIso8601String(),
           true,
           3,
           .2,
@@ -269,8 +318,6 @@ void main() {
       });
 
       test('setData', () {
-        final date = DateTime.now();
-        final blob = Blob.fromData('', Uint8List(0));
         final array = MutableArray()
           ..setData([
             'x',
@@ -279,8 +326,8 @@ void main() {
             .2,
             3,
             true,
-            date,
-            blob,
+            testDate,
+            testBlob,
             <Object?>[],
             <String, Object>{},
           ]);
@@ -292,8 +339,8 @@ void main() {
           .2,
           3,
           true,
-          date.toIso8601String(),
-          blob,
+          testDate.toIso8601String(),
+          testBlob,
           <Object?>[],
           <String, Object>{},
         ]);
@@ -309,9 +356,7 @@ void main() {
 
 Array immutableArray([List<Object?>? data]) {
   final array = MutableArray(data) as MutableArrayImpl;
-  final encoder = fl.FleeceEncoder()
-    // FleeceEncoderContext is needed to compare unsaved Blobs in test.
-    ..extraInfo = FleeceEncoderContext(encodeQueryParameter: true);
+  final encoder = fl.FleeceEncoder();
   array.encodeTo(encoder);
   final fleeceData = encoder.finish();
   final root = MRoot.fromData(

--- a/packages/cbl_e2e_tests/lib/src/document/document_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/document/document_test.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:cbl/cbl.dart';
 
 import '../../test_binding_impl.dart';
+import '../fixtures/values.dart';
 import '../test_binding.dart';
 import '../utils/api_variant.dart';
 import '../utils/database_utils.dart';
@@ -107,11 +108,74 @@ void main() {
       );
     });
 
+    test('toJson', () async {
+      final db = await openAsyncTestDatabase();
+      final blob = Blob.fromData('contentType', Uint8List(0));
+
+      expect((await savedDocument(db, {})).toJson(), '{}');
+      expect(
+        (await savedDocument(db, {
+          'null': null,
+          'string': 'a',
+          'integer': 1,
+          'float': .2,
+          'bool': true,
+          'date': testDate,
+          'blob': blob,
+          'array': <Object?>[],
+          'dictionary': <String, Object?>{},
+        }))
+            .toJson(),
+        json(
+          '''
+          {
+            "null": null, 
+            "string": "a", 
+            "integer": 1, 
+            "float": 0.2, 
+            "bool": true, 
+            "date": "${testDate.toIso8601String()}", 
+            "blob": ${blob.toJson()}, 
+            "array": [], 
+            "dictionary": {}
+          }
+          ''',
+        ),
+      );
+      expect(MutableDocument().toJson(), '{}');
+      expect(
+        MutableDocument({
+          'null': null,
+          'string': 'a',
+          'integer': 1,
+          'float': .2,
+          'bool': true,
+          'date': testDate,
+          'blob': testBlob,
+          'array': <Object?>[],
+          'dictionary': <String, Object?>{},
+        }).toJson(),
+        json(
+          '''
+          {
+            "null": null, 
+            "string": "a", 
+            "integer": 1, 
+            "float": 0.2, 
+            "bool": true, 
+            "date": "${testDate.toIso8601String()}", 
+            "blob": ${testBlob.toJson()}, 
+            "array": [], 
+            "dictionary": {}
+          }
+          ''',
+        ),
+      );
+    });
+
     group('immutable', () {
       apiTest('implements DictionaryInterface for properties', () async {
         final db = await openTestDatabase();
-        final date = DateTime.now();
-        final blob = Blob.fromData('', Uint8List(0));
         final doc = await savedDocument(db, {
           'value': 'x',
           'string': 'a',
@@ -119,8 +183,8 @@ void main() {
           'float': .2,
           'number': 3,
           'bool': true,
-          'date': date,
-          'blob': blob,
+          'date': testDate,
+          'blob': testBlob,
           'array': [false],
           'dictionary': {'key': 'value'},
         });
@@ -147,8 +211,8 @@ void main() {
         expect(doc.float('float'), .2);
         expect(doc.number('number'), 3);
         expect(doc.boolean('bool'), true);
-        expect(doc.date('date'), date);
-        expect(doc.blob('blob'), blob);
+        expect(doc.date('date'), testDate);
+        expect(doc.blob('blob'), testBlob);
         expect(doc.array('array'), MutableArray([false]));
         expect(
           doc.dictionary('dictionary'),
@@ -163,8 +227,8 @@ void main() {
           'float': .2,
           'number': 3,
           'bool': true,
-          'date': date.toIso8601String(),
-          'blob': blob,
+          'date': testDate.toIso8601String(),
+          'blob': testBlob,
           'array': [false],
           'dictionary': {'key': 'value'},
         });
@@ -230,8 +294,6 @@ void main() {
     });
 
     test('implements MutableDictionaryInterface for properties', () {
-      final date = DateTime.now();
-      final blob = Blob.fromData('', Uint8List(0));
       final doc = MutableDocument()
         ..setValue('x', key: 'value')
         ..setString('a', key: 'string')
@@ -239,8 +301,8 @@ void main() {
         ..setFloat(.2, key: 'float')
         ..setNumber(3, key: 'number')
         ..setBoolean(true, key: 'bool')
-        ..setDate(date, key: 'date')
-        ..setBlob(blob, key: 'blob')
+        ..setDate(testDate, key: 'date')
+        ..setBlob(testBlob, key: 'blob')
         ..setArray(MutableArray([true]), key: 'array')
         ..setDictionary(MutableDictionary({'key': 'value'}), key: 'dictionary');
 
@@ -251,8 +313,8 @@ void main() {
         'float': .2,
         'number': 3,
         'bool': true,
-        'date': date.toIso8601String(),
-        'blob': blob,
+        'date': testDate.toIso8601String(),
+        'blob': testBlob,
         'array': [true],
         'dictionary': {'key': 'value'},
       });

--- a/packages/cbl_e2e_tests/lib/src/document/fragment_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/document/fragment_test.dart
@@ -1,8 +1,7 @@
-import 'dart:typed_data';
-
 import 'package:cbl/cbl.dart';
 
 import '../../test_binding_impl.dart';
+import '../fixtures/values.dart';
 import '../test_binding.dart';
 
 void main() {
@@ -27,8 +26,6 @@ void main() {
   });
 
   test('getters for values in array', () {
-    final date = DateTime.now();
-    final blob = Blob.fromData('', Uint8List(0));
     final array = MutableArray([
       'x',
       'a',
@@ -36,8 +33,8 @@ void main() {
       .2,
       3,
       true,
-      date,
-      blob,
+      testDate,
+      testBlob,
       <Object?>[true],
       <String, Object>{'key': 'value'},
     ]);
@@ -49,15 +46,13 @@ void main() {
     expect(array[3].float, .2);
     expect(array[4].number, 3);
     expect(array[5].boolean, true);
-    expect(array[6].date, date);
-    expect(array[7].blob, blob);
+    expect(array[6].date, testDate);
+    expect(array[7].blob, testBlob);
     expect(array[8].array, MutableArray([true]));
     expect(array[9].dictionary, MutableDictionary({'key': 'value'}));
   });
 
   test('getters for values in dictionary', () {
-    final date = DateTime.now();
-    final blob = Blob.fromData('', Uint8List(0));
     final dictionary = MutableDictionary({
       'value': 'x',
       'string': 'a',
@@ -65,8 +60,8 @@ void main() {
       'float': .2,
       'number': 3,
       'bool': true,
-      'date': date,
-      'blob': blob,
+      'date': testDate,
+      'blob': testBlob,
       'array': [true],
       'dictionary': {'key': 'value'},
     });
@@ -78,8 +73,8 @@ void main() {
     expect(dictionary['float'].float, .2);
     expect(dictionary['number'].number, 3);
     expect(dictionary['bool'].boolean, true);
-    expect(dictionary['date'].date, date);
-    expect(dictionary['blob'].blob, blob);
+    expect(dictionary['date'].date, testDate);
+    expect(dictionary['blob'].blob, testBlob);
     expect(dictionary['array'].array, MutableArray([true]));
     expect(
       dictionary['dictionary'].dictionary,
@@ -118,8 +113,6 @@ void main() {
   });
 
   test('setters for index in array set value', () {
-    final date = DateTime.now();
-    final blob = Blob.fromData('', Uint8List(0));
     final array = MutableArray([null]);
 
     array[0].value = 'x';
@@ -134,10 +127,10 @@ void main() {
     expect(array.value(0), 3);
     array[0].boolean = true;
     expect(array.value(0), true);
-    array[0].date = date;
-    expect(array.date(0), date);
-    array[0].blob = blob;
-    expect(array.value(0), blob);
+    array[0].date = testDate;
+    expect(array.date(0), testDate);
+    array[0].blob = testBlob;
+    expect(array.value(0), testBlob);
     array[0].array = MutableArray([true]);
     expect(array.value(0), MutableArray([true]));
     array[0].dictionary = MutableDictionary({'key': 'value'});
@@ -145,8 +138,6 @@ void main() {
   });
 
   test('setters for keys in dictionary set value', () {
-    final date = DateTime.now();
-    final blob = Blob.fromData('', Uint8List(0));
     final dictionary = MutableDictionary({'x': null});
 
     dictionary['x'].value = 'x';
@@ -161,10 +152,10 @@ void main() {
     expect(dictionary.value('x'), 3);
     dictionary['x'].boolean = true;
     expect(dictionary.value('x'), true);
-    dictionary['x'].date = date;
-    expect(dictionary.date('x'), date);
-    dictionary['x'].blob = blob;
-    expect(dictionary.value('x'), blob);
+    dictionary['x'].date = testDate;
+    expect(dictionary.date('x'), testDate);
+    dictionary['x'].blob = testBlob;
+    expect(dictionary.value('x'), testBlob);
     dictionary['x'].array = MutableArray([true]);
     expect(dictionary.value('x'), MutableArray([true]));
     dictionary['x'].dictionary = MutableDictionary({'key': 'value'});
@@ -172,8 +163,6 @@ void main() {
   });
 
   test('setters throw if Fragment index is out of range', () {
-    final date = DateTime.now();
-    final blob = Blob.fromData('', Uint8List(0));
     final array = MutableArray();
 
     expect(() => array[0].value = 'x', throwsRangeError);
@@ -182,15 +171,13 @@ void main() {
     expect(() => array[0].float = 0, throwsRangeError);
     expect(() => array[0].number = 0, throwsRangeError);
     expect(() => array[0].boolean = false, throwsRangeError);
-    expect(() => array[0].date = date, throwsRangeError);
-    expect(() => array[0].blob = blob, throwsRangeError);
+    expect(() => array[0].date = testDate, throwsRangeError);
+    expect(() => array[0].blob = testBlob, throwsRangeError);
     expect(() => array[0].array = MutableArray(), throwsRangeError);
     expect(() => array[0].dictionary = MutableDictionary(), throwsRangeError);
   });
 
   test('setters throw if Fragment path is outside existing collection', () {
-    final date = DateTime.now();
-    final blob = Blob.fromData('', Uint8List(0));
     final array = MutableArray();
 
     expect(() => array[0][0].value = 'x', throwsStateError);
@@ -199,8 +186,8 @@ void main() {
     expect(() => array[0][0].float = 0, throwsStateError);
     expect(() => array[0][0].number = 0, throwsStateError);
     expect(() => array[0][0].boolean = false, throwsStateError);
-    expect(() => array[0][0].date = date, throwsStateError);
-    expect(() => array[0][0].blob = blob, throwsStateError);
+    expect(() => array[0][0].date = testDate, throwsStateError);
+    expect(() => array[0][0].blob = testBlob, throwsStateError);
     expect(() => array[0][0].array = MutableArray(), throwsStateError);
     expect(
         () => array[0][0].dictionary = MutableDictionary(), throwsStateError);

--- a/packages/cbl_e2e_tests/lib/src/fixtures/values.dart
+++ b/packages/cbl_e2e_tests/lib/src/fixtures/values.dart
@@ -1,0 +1,10 @@
+import 'package:cbl/src/document/blob.dart';
+
+final testBlob = BlobImpl.fromProperties({
+  '@type': 'blob',
+  'content_type': 'application/octet-stream',
+  'length': 0,
+  'digest': 'sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=',
+});
+
+final testDate = DateTime.now();

--- a/packages/cbl_e2e_tests/lib/src/query/parameters_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/query/parameters_test.dart
@@ -1,8 +1,7 @@
-import 'dart:typed_data';
-
 import 'package:cbl/cbl.dart';
 
 import '../../test_binding_impl.dart';
+import '../fixtures/values.dart';
 import '../test_binding.dart';
 
 void main() {
@@ -15,8 +14,6 @@ void main() {
     });
 
     test('set parameters', () {
-      final date = DateTime.now();
-      final blob = Blob.fromData('', Uint8List(0));
       final parameters = Parameters();
 
       // ignore: cascade_invocations
@@ -38,11 +35,11 @@ void main() {
       parameters.setBoolean(true, name: 'boolean');
       expect(parameters.value('boolean'), true);
 
-      parameters.setDate(date, name: 'date');
-      expect(parameters.value('date'), date.toIso8601String());
+      parameters.setDate(testDate, name: 'date');
+      expect(parameters.value('date'), testDate.toIso8601String());
 
-      parameters.setBlob(blob, name: 'blob');
-      expect(parameters.value('blob'), blob);
+      parameters.setBlob(testBlob, name: 'blob');
+      expect(parameters.value('blob'), testBlob);
 
       parameters.setArray(MutableArray([true]), name: 'array');
       expect(parameters.value('array'), MutableArray([true]));

--- a/packages/cbl_e2e_tests/lib/src/query/result_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/query/result_test.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:cbl/cbl.dart';
 import 'package:cbl/src/document/array.dart';
 import 'package:cbl/src/document/common.dart';
@@ -8,6 +6,7 @@ import 'package:cbl/src/fleece/integration/integration.dart';
 import 'package:cbl/src/query/result.dart';
 
 import '../../test_binding_impl.dart';
+import '../fixtures/values.dart';
 import '../test_binding.dart';
 import '../utils/api_variant.dart';
 import '../utils/database_utils.dart';
@@ -70,18 +69,16 @@ void main() {
     });
 
     test('get date', () {
-      final date = DateTime.now();
-      final result = testResult(['a'], [date]);
-      expect(result.date(0), date);
-      expect(result.date('a'), date);
+      final result = testResult(['a'], [testDate]);
+      expect(result.date(0), testDate);
+      expect(result.date('a'), testDate);
       expect(result.blob('b'), null);
     });
 
     test('get blob', () {
-      final blob = Blob.fromData('', Uint8List(0));
-      final result = testResult(['a'], [blob]);
-      expect(result.blob(0), blob);
-      expect(result.blob('a'), blob);
+      final result = testResult(['a'], [testBlob]);
+      expect(result.blob(0), testBlob);
+      expect(result.blob('a'), testBlob);
       expect(result.blob('b'), null);
     });
 

--- a/packages/cbl_ffi/lib/src/data.dart
+++ b/packages/cbl_ffi/lib/src/data.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:isolate';
 import 'dart:typed_data';
 
@@ -15,6 +16,9 @@ abstract class Data {
   Uint8List toTypedList();
 
   SliceResult toSliceResult();
+
+  String toDartString({Encoding encoding = utf8}) =>
+      encoding.decode(toTypedList());
 
   TransferableData _createTransferableData();
 }


### PR DESCRIPTION
Adds `toJson` method to:

- `Document`
- `Array`
- `Dictionary`
- `Blob`

Also fixes equality of `Blob`.

Closes #117
Closes #138