### PR TITLE
fix: initialize native libraries exactly once

### DIFF
--- a/native/cbl-dart/src/CBL+Dart.cpp
+++ b/native/cbl-dart/src/CBL+Dart.cpp
@@ -7,7 +7,31 @@
 #include "CBL+Dart.h"
 #include "Utils.hh"
 
-void CBLDart_InitializeApiDL(void *data) { Dart_InitializeApiDL(data); }
+std::mutex initializeMutex;
+bool initialized = false;
+
+bool CBLDart_Initialize(void *dartInitializeDlData, void *cblInitContext,
+                        CBLError *errorOut) {
+  std::scoped_lock lock(initializeMutex);
+
+  if (initialized) {
+    // Only initialize libraries once.
+    return true;
+  }
+
+#ifdef __ANDROID__
+  // Initialize the Couchbase Lite library.
+  if (!CBL_Init(reinterpret_cast<CBLInitContext *>(cblInitContext), errorOut)) {
+    return false;
+  }
+#endif
+
+  // Initialize the Dart API for this dynamic library.
+  Dart_InitializeApiDL(dartInitializeDlData);
+
+  initialized = true;
+  return true;
+}
 
 // -- AsyncCallback
 

--- a/native/cbl-dart/src/CBL+Dart.cpp
+++ b/native/cbl-dart/src/CBL+Dart.cpp
@@ -21,7 +21,8 @@ bool CBLDart_Initialize(void *dartInitializeDlData, void *cblInitContext,
 
 #ifdef __ANDROID__
   // Initialize the Couchbase Lite library.
-  if (!CBL_Init(reinterpret_cast<CBLInitContext *>(cblInitContext), errorOut)) {
+  if (!CBL_Init(*reinterpret_cast<CBLInitContext *>(cblInitContext),
+                errorOut)) {
     return false;
   }
 #endif

--- a/native/cbl-dart/src/CBL+Dart.h
+++ b/native/cbl-dart/src/CBL+Dart.h
@@ -17,8 +17,16 @@
 
 extern "C" {
 
+/**
+ * Initializes the native libraries.
+ *
+ * This function can be called multiple times and is thread save. The
+ * libraries are only initialized by the first call and subsequent calls are
+ * NOOPs.
+ */
 CBLDART_EXPORT
-void CBLDart_InitializeApiDL(void *data);
+bool CBLDart_Initialize(void *dartInitializeDlData, void *cblInitContext,
+                        CBLError *errorOut);
 
 // -- Callbacks
 

--- a/packages/cbl/lib/src/init.dart
+++ b/packages/cbl/lib/src/init.dart
@@ -12,11 +12,11 @@ void initIsolate({required Libraries libraries}) {
 }
 
 /// Initializes this isolate for use of Couchbase Lite, and initializes the
-/// native library.
+/// native libraries.
 void initMainIsolate({
   required Libraries libraries,
   CBLInitContext? context,
 }) {
   initIsolate(libraries: libraries);
-  ffi.cblBindings.base.init(context);
+  ffi.cblBindings.base.initializeNativeLibraries(context);
 }

--- a/packages/cbl_ffi/lib/src/base.dart
+++ b/packages/cbl_ffi/lib/src/base.dart
@@ -52,12 +52,12 @@ class _CBLInitContext extends Struct {
 
 typedef _CBLDart_Initialize_C = Uint8 Function(
   Pointer<Void> dartInitializeDlData,
-  _CBLInitContext cblInitContext,
+  Pointer<_CBLInitContext> cblInitContext,
   Pointer<CBLError> errorOut,
 );
 typedef _CBLDart_Initialize = int Function(
   Pointer<Void> dartInitializeDlData,
-  _CBLInitContext cblInitContext,
+  Pointer<_CBLInitContext> cblInitContext,
   Pointer<CBLError> errorOut,
 );
 
@@ -383,7 +383,7 @@ class BaseBindings extends Bindings {
 
       _initialize(
         NativeApi.initializeApiDLData,
-        _context.ref,
+        _context,
         globalCBLError,
       ).checkCBLError();
     });

--- a/packages/cbl_ffi/lib/src/base.dart
+++ b/packages/cbl_ffi/lib/src/base.dart
@@ -335,8 +335,8 @@ typedef _CBLListener_Remove = void Function(
 class BaseBindings extends Bindings {
   BaseBindings(Bindings parent) : super(parent) {
     _initialize =
-        libs.cbl.lookupFunction<_CBLDart_Initialize_C, _CBLDart_Initialize>(
-      'CBL_Initialize',
+        libs.cblDart.lookupFunction<_CBLDart_Initialize_C, _CBLDart_Initialize>(
+      'CBLDart_Initialize',
     );
 
     _bindCBLRefCountedToDartObject = libs.cblDart.lookupFunction<

--- a/packages/cbl_ffi/lib/src/base.dart
+++ b/packages/cbl_ffi/lib/src/base.dart
@@ -52,12 +52,12 @@ class _CBLInitContext extends Struct {
 
 typedef _CBLDart_Initialize_C = Uint8 Function(
   Pointer<Void> dartInitializeDlData,
-  Pointer<_CBLInitContext> cblInitContext,
+  Pointer<Void> cblInitContext,
   Pointer<CBLError> errorOut,
 );
 typedef _CBLDart_Initialize = int Function(
   Pointer<Void> dartInitializeDlData,
-  Pointer<_CBLInitContext> cblInitContext,
+  Pointer<Void> cblInitContext,
   Pointer<CBLError> errorOut,
 );
 
@@ -381,11 +381,17 @@ class BaseBindings extends Bindings {
           ..ref.tempDir = context.tempDir.toNativeUtf8(allocator: zoneArena);
       }
 
-      _initialize(
+      // The `globalCBLError` cannot be used at this point because it requires
+      // initialization to be completed.
+      final error = zoneArena<CBLError>();
+
+      if (!_initialize(
         NativeApi.initializeApiDLData,
-        _context,
-        globalCBLError,
-      ).checkCBLError();
+        _context.cast(),
+        error,
+      ).toBool()) {
+        throw CBLErrorException.fromCBLError(error);
+      }
     });
   }
 

--- a/packages/cbl_ffi/lib/src/base.dart
+++ b/packages/cbl_ffi/lib/src/base.dart
@@ -38,9 +38,6 @@ extension OptionIterable<T extends Option> on Iterable<T> {
 
 // === Init ====================================================================
 
-typedef _CBLDart_InitializeApiDL_C = Void Function(Pointer<Void> data);
-typedef _CBLDart_InitializeApiDL = void Function(Pointer<Void> data);
-
 class CBLInitContext {
   CBLInitContext({required this.filesDir, required this.tempDir});
 
@@ -53,12 +50,14 @@ class _CBLInitContext extends Struct {
   external Pointer<Utf8> tempDir;
 }
 
-typedef _CBL_Init_C = Uint8 Function(
-  _CBLInitContext context,
+typedef _CBLDart_Initialize_C = Uint8 Function(
+  Pointer<Void> dartInitializeDlData,
+  _CBLInitContext cblInitContext,
   Pointer<CBLError> errorOut,
 );
-typedef _CBL_Init = int Function(
-  _CBLInitContext context,
+typedef _CBLDart_Initialize = int Function(
+  Pointer<Void> dartInitializeDlData,
+  _CBLInitContext cblInitContext,
   Pointer<CBLError> errorOut,
 );
 
@@ -335,15 +334,11 @@ typedef _CBLListener_Remove = void Function(
 
 class BaseBindings extends Bindings {
   BaseBindings(Bindings parent) : super(parent) {
-    _initializeApiDL = libs.cblDart
-        .lookupFunction<_CBLDart_InitializeApiDL_C, _CBLDart_InitializeApiDL>(
-      'CBLDart_InitializeApiDL',
+    _initialize =
+        libs.cbl.lookupFunction<_CBLDart_Initialize_C, _CBLDart_Initialize>(
+      'CBL_Initialize',
     );
-    if (io.Platform.isAndroid) {
-      _init = libs.cbl.lookupFunction<_CBL_Init_C, _CBL_Init>(
-        'CBL_Init',
-      );
-    }
+
     _bindCBLRefCountedToDartObject = libs.cblDart.lookupFunction<
         _CBLDart_BindCBLRefCountedToDartObject_C,
         _CBLDart_BindCBLRefCountedToDartObject>(
@@ -366,8 +361,7 @@ class BaseBindings extends Bindings {
     );
   }
 
-  late final _CBLDart_InitializeApiDL _initializeApiDL;
-  late final _CBL_Init _init;
+  late final _CBLDart_Initialize _initialize;
   late final _CBLDart_BindCBLRefCountedToDartObject
       _bindCBLRefCountedToDartObject;
   late final _CBLDart_SetDebugRefCounted _setDebugRefCounted;
@@ -375,23 +369,24 @@ class BaseBindings extends Bindings {
   late final _CBLDart_CBLError_Message _getErrorMessage;
   late final _CBLListener_Remove _removeListener;
 
-  void init([CBLInitContext? context]) {
+  void initializeNativeLibraries([CBLInitContext? context]) {
     assert(!io.Platform.isAndroid || context != null);
 
-    _initializeApiDL(NativeApi.initializeApiDLData);
+    withZoneArena(() {
+      Pointer<_CBLInitContext> _context = nullptr;
 
-    if (context != null) {
-      withZoneArena(() {
-        final _context = zoneArena<_CBLInitContext>()
+      if (context != null) {
+        _context = zoneArena<_CBLInitContext>()
           ..ref.filesDir = context.filesDir.toNativeUtf8(allocator: zoneArena)
           ..ref.tempDir = context.tempDir.toNativeUtf8(allocator: zoneArena);
+      }
 
-        _init(
-          _context.ref,
-          globalCBLError,
-        ).checkCBLError();
-      });
-    }
+      _initialize(
+        NativeApi.initializeApiDLData,
+        _context.ref,
+        globalCBLError,
+      ).checkCBLError();
+    });
   }
 
   void bindCBLRefCountedToDartObject(


### PR DESCRIPTION
With this change `CBLDart_Initialize` can be called multiple times, but only initializes the native libraries once. This is necessary to allow hot restarting of Flutter apps, where only the Dart Isolates are fully restarted, but native libraries remain loaded.

Fixes #175