### PR TITLE
feat: return mutable copies from `toMutable` methods

### DIFF
--- a/packages/cbl/lib/src/document/array.dart
+++ b/packages/cbl/lib/src/document/array.dart
@@ -562,7 +562,11 @@ class MutableArrayImpl extends ArrayImpl implements MutableArray {
   // === Array =================================================================
 
   @override
-  MutableArray toMutable() => MutableArray(toPlainList(growable: false));
+  MutableArray toMutable() =>
+      // We make a deep copy of this array, to allow the result to be used
+      // with a different document and prevent modifications of this array
+      // or the result affect each other.
+      MutableArray(toPlainList(growable: false));
 
   // === CblConversions ========================================================
 

--- a/packages/cbl/lib/src/document/array.dart
+++ b/packages/cbl/lib/src/document/array.dart
@@ -562,7 +562,7 @@ class MutableArrayImpl extends ArrayImpl implements MutableArray {
   // === Array =================================================================
 
   @override
-  MutableArray toMutable() => this;
+  MutableArray toMutable() => MutableArray(toPlainList(growable: false));
 
   // === CblConversions ========================================================
 

--- a/packages/cbl/lib/src/document/dictionary.dart
+++ b/packages/cbl/lib/src/document/dictionary.dart
@@ -372,7 +372,11 @@ class MutableDictionaryImpl extends DictionaryImpl
   // === Dictionary ============================================================
 
   @override
-  MutableDictionary toMutable() => MutableDictionary(toPlainMap());
+  MutableDictionary toMutable() =>
+      // We make a deep copy of this dictionary, to allow the result to be used
+      // with a different document and prevent modifications of this dictionary
+      // or the result affect each other.
+      MutableDictionary(toPlainMap());
 
   // === CblConversions ========================================================
 

--- a/packages/cbl/lib/src/document/dictionary.dart
+++ b/packages/cbl/lib/src/document/dictionary.dart
@@ -372,7 +372,7 @@ class MutableDictionaryImpl extends DictionaryImpl
   // === Dictionary ============================================================
 
   @override
-  MutableDictionary toMutable() => this;
+  MutableDictionary toMutable() => MutableDictionary(toPlainMap());
 
   // === CblConversions ========================================================
 

--- a/packages/cbl/lib/src/document/document.dart
+++ b/packages/cbl/lib/src/document/document.dart
@@ -95,7 +95,7 @@ class NewDocumentDelegate extends DocumentDelegate {
   final sequence = 0;
 
   @override
-  late EncodedData properties = _emptyProperties;
+  EncodedData properties = _emptyProperties;
 
   @override
   DocumentDelegate toMutable() => NewDocumentDelegate.mutableCopy(this);
@@ -380,5 +380,11 @@ class MutableDelegateDocument extends DelegateDocument
   MutableFragment operator [](String key) => _mutableProperties[key];
 
   @override
-  MutableDocument toMutable() => this;
+  MutableDocument toMutable() => MutableDelegateDocument.fromDelegate(
+        delegate.toMutable(),
+        database: _database,
+        // We make a deep copy of the current properties of this mutable
+        // document, to transfer changes that have been made them.
+        data: toPlainMap(),
+      );
 }

--- a/packages/cbl/lib/src/document/document.dart
+++ b/packages/cbl/lib/src/document/document.dart
@@ -383,8 +383,9 @@ class MutableDelegateDocument extends DelegateDocument
   MutableDocument toMutable() => MutableDelegateDocument.fromDelegate(
         delegate.toMutable(),
         database: _database,
-        // We make a deep copy of the current properties of this mutable
-        // document, to transfer changes that have been made them.
+        // We make a deep copy of the properties, to include modifications of
+        // this document, which have not been synced with the delegate, in the
+        // copy.
         data: toPlainMap(),
       );
 }

--- a/packages/cbl_e2e_tests/lib/src/document/array_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/document/array_test.dart
@@ -219,7 +219,8 @@ void main() {
       test('toMutable', () {
         final array = MutableArray([true]);
         final mutableArray = array.toMutable();
-        expect(mutableArray, same(array));
+        expect(mutableArray, array);
+        expect(mutableArray, isNot(same(array)));
       });
 
       test('set values', () {

--- a/packages/cbl_e2e_tests/lib/src/document/dictionary_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/document/dictionary_test.dart
@@ -237,7 +237,8 @@ void main() {
       test('toMutable', () {
         final dictionary = MutableDictionary({'a': true});
         final mutableDictionary = dictionary.toMutable();
-        expect(mutableDictionary, same(dictionary));
+        expect(mutableDictionary, dictionary);
+        expect(mutableDictionary, isNot(same(dictionary)));
       });
 
       test('set values', () {

--- a/packages/cbl_e2e_tests/lib/src/document/document_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/document/document_test.dart
@@ -242,14 +242,6 @@ void main() {
         expect(doc.toList(), ['a', 'b', 'c']);
       });
 
-      apiTest('toMutable', () async {
-        final db = await openTestDatabase();
-        final doc = await savedDocument(db, {'type': 'immutable'});
-        expect(doc, isNot(isA<MutableDocument>()));
-        final mutableDoc = doc.toMutable();
-        expect(mutableDoc, doc);
-      });
-
       test('toString', () {
         final db = openSyncTestDatabase();
         final doc = MutableDocument();
@@ -265,6 +257,32 @@ void main() {
           ')',
         );
       });
+    });
+
+    test('toMutable: new mutable doc', () {
+      final doc = MutableDocument({'a': true});
+
+      final mutableDoc = doc.toMutable();
+      expect(mutableDoc, doc);
+      expect(mutableDoc, isNot(same(doc)));
+    });
+
+    apiTest('toMutable: saved immutable doc', () async {
+      final db = await openTestDatabase();
+      final doc = await savedDocument(db, {'a': true});
+
+      final mutableDoc = doc.toMutable();
+      expect(mutableDoc, doc);
+      expect(mutableDoc, isNot(same(doc)));
+    });
+
+    apiTest('toMutable: saved mutable doc', () async {
+      final db = await openTestDatabase();
+      final doc = (await savedDocument(db, {'a': true})).toMutable();
+
+      final mutableDoc = doc.toMutable();
+      expect(mutableDoc, doc);
+      expect(mutableDoc, isNot(same(doc)));
     });
 
     group('mutable', () {
@@ -332,11 +350,6 @@ void main() {
 
       doc['value'].value = 'x';
       expect(doc['value'].value, 'x');
-    });
-
-    test('toMutable', () {
-      final doc = MutableDocument();
-      expect(doc.toMutable(), same(doc));
     });
 
     test('toString', () {


### PR DESCRIPTION
With this change, containers which are already mutable don't just return themselves from `toMutable`, but instead return a mutable deep copy.

Closes #136