### PR TITLE
chore: update cbl_libcblitedart_api to 10.0.0

### DIFF
--- a/packages/cbl/pubspec.yaml
+++ b/packages/cbl/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   archive: '>=3.6.1 <5.0.0'
   cbl_libcblite_api: 3.2.4
-  cbl_libcblitedart_api: 9.0.0
+  cbl_libcblitedart_api: 10.0.0
   characters: ^1.1.0
   collection: ^1.15.0
   ffi: ^2.0.1

--- a/packages/cbl_dart/pubspec.yaml
+++ b/packages/cbl_dart/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   cbl: ^3.5.0
   cbl_libcblite_api: 3.2.4
-  cbl_libcblitedart_api: 9.0.0
+  cbl_libcblitedart_api: 10.0.0
   crypto: ^3.0.1
   logging: ^1.1.0
   path: ^1.8.0

--- a/packages/cbl_flutter_ce/pubspec.yaml
+++ b/packages/cbl_flutter_ce/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   cbl_flutter_install: 0.1.0+3
   cbl_flutter_platform_interface: ^3.1.3
   cbl_libcblite_api: 3.2.4
-  cbl_libcblitedart_api: 9.0.0
+  cbl_libcblitedart_api: 10.0.0
   flutter:
     sdk: flutter
 

--- a/packages/cbl_flutter_ee/pubspec.yaml
+++ b/packages/cbl_flutter_ee/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   cbl_flutter_install: 0.1.0+3
   cbl_flutter_platform_interface: ^3.1.3
   cbl_libcblite_api: 3.2.4
-  cbl_libcblitedart_api: 9.0.0
+  cbl_libcblitedart_api: 10.0.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
## Summary
- Updates `cbl_libcblitedart_api` dependency from 9.0.0 to 10.0.0 across all dependent packages

🤖 Generated with [Claude Code](https://claude.ai/code)