### PR TITLE
ci: upgrade clang-format to v4.16.0 and pin version to 21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,8 +59,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check formatting
-        uses: jidicula/clang-format-action@v4.14.0
+        uses: jidicula/clang-format-action@v4.16.0
         with:
+          clang-format-version: '21'
           check-path: 'native/couchbase-lite-dart'
 
   analyze-dart:

--- a/native/couchbase-lite-dart/include/CBL+Dart.h
+++ b/native/couchbase-lite-dart/include/CBL+Dart.h
@@ -38,15 +38,15 @@ enum CBLDartInitializeResult {
  * NOOPs.
  */
 CBLDART_EXPORT
-CBLDartInitializeResult CBLDart_Initialize(void *dartInitializeDlData,
-                                           void *cblInitContext,
-                                           CBLError *errorOut);
+CBLDartInitializeResult CBLDart_Initialize(void* dartInitializeDlData,
+                                           void* cblInitContext,
+                                           CBLError* errorOut);
 
 // === Dart Native ============================================================
 
 // === Async Callbacks
 
-typedef struct _CBLDart_AsyncCallback *CBLDart_AsyncCallback;
+typedef struct _CBLDart_AsyncCallback* CBLDart_AsyncCallback;
 
 CBLDART_EXPORT
 CBLDart_AsyncCallback CBLDart_AsyncCallback_New(uint32_t id, Dart_Port sendPort,
@@ -64,7 +64,7 @@ void CBLDart_AsyncCallback_CallForTest(CBLDart_AsyncCallback callback,
 
 // === Completer
 
-typedef struct _CBLDart_Completer *CBLDart_Completer;
+typedef struct _CBLDart_Completer* CBLDart_Completer;
 
 CBLDART_EXPORT
 void CBLDart_Completer_Complete(CBLDart_Completer completer, uint64_t result);
@@ -95,11 +95,11 @@ CBLDART_EXPORT
 void CBLDart_CBLLog_SetCallbackLevel(CBLLogLevel level);
 
 CBLDART_EXPORT
-bool CBLDart_CBLLog_SetFileConfig(CBLLogFileConfiguration *config,
-                                  CBLError *errorOut);
+bool CBLDart_CBLLog_SetFileConfig(CBLLogFileConfiguration* config,
+                                  CBLError* errorOut);
 
 CBLDART_EXPORT
-CBLLogFileConfiguration *CBLDart_CBLLog_GetFileConfig();
+CBLLogFileConfiguration* CBLDart_CBLLog_GetFileConfig();
 
 CBLDART_EXPORT
 bool CBLDart_CBLLog_SetSentryBreadcrumbs(bool enabled);
@@ -122,31 +122,31 @@ CBLDart_CBLDatabaseConfiguration CBLDart_CBLDatabaseConfiguration_Default();
 
 CBLDART_EXPORT
 bool CBLDart_CBL_CopyDatabase(FLString fromPath, FLString toName,
-                              const CBLDart_CBLDatabaseConfiguration *config,
-                              CBLError *outError);
+                              const CBLDart_CBLDatabaseConfiguration* config,
+                              CBLError* outError);
 
 CBLDART_EXPORT
-CBLDatabase *CBLDart_CBLDatabase_Open(FLString name,
-                                      CBLDart_CBLDatabaseConfiguration *config,
-                                      CBLError *errorOut);
+CBLDatabase* CBLDart_CBLDatabase_Open(FLString name,
+                                      CBLDart_CBLDatabaseConfiguration* config,
+                                      CBLError* errorOut);
 
 CBLDART_EXPORT
-void CBLDart_CBLDatabase_Release(CBLDatabase *database);
+void CBLDart_CBLDatabase_Release(CBLDatabase* database);
 
 CBLDART_EXPORT
-bool CBLDart_CBLDatabase_Close(CBLDatabase *database, bool andDelete,
-                               CBLError *errorOut);
+bool CBLDart_CBLDatabase_Close(CBLDatabase* database, bool andDelete,
+                               CBLError* errorOut);
 
 // === Collection
 
 CBLDART_EXPORT
 void CBLDart_CBLCollection_AddDocumentChangeListener(
-    const CBLDatabase *db, const CBLCollection *collection,
+    const CBLDatabase* db, const CBLCollection* collection,
     const FLString docID, CBLDart_AsyncCallback listener);
 
 CBLDART_EXPORT
-void CBLDart_CBLCollection_AddChangeListener(const CBLDatabase *db,
-                                             const CBLCollection *collection,
+void CBLDart_CBLCollection_AddChangeListener(const CBLDatabase* db,
+                                             const CBLCollection* collection,
                                              CBLDart_AsyncCallback listener);
 
 typedef enum : uint8_t {
@@ -168,7 +168,7 @@ struct CBLDart_CBLIndexSpec {
   unsigned dimensions;
   unsigned centroids;
   bool isLazy;
-  void *encoding;
+  void* encoding;
   uint32_t metric;
   unsigned minTrainingSize;
   unsigned maxTrainingSize;
@@ -176,15 +176,15 @@ struct CBLDart_CBLIndexSpec {
 };
 
 CBLDART_EXPORT
-bool CBLDart_CBLCollection_CreateIndex(CBLCollection *collection, FLString name,
+bool CBLDart_CBLCollection_CreateIndex(CBLCollection* collection, FLString name,
                                        CBLDart_CBLIndexSpec indexSpec,
-                                       CBLError *errorOut);
+                                       CBLError* errorOut);
 
 // === Query
 
 CBLDART_EXPORT
-CBLListenerToken *CBLDart_CBLQuery_AddChangeListener(
-    const CBLDatabase *db, CBLQuery *query, CBLDart_AsyncCallback listener);
+CBLListenerToken* CBLDart_CBLQuery_AddChangeListener(
+    const CBLDatabase* db, CBLQuery* query, CBLDart_AsyncCallback listener);
 
 // === Prediction
 
@@ -193,7 +193,7 @@ typedef void (*CBLDart_PredictiveModel_PredictionAsync)(
     FLDict input, CBLDart_Completer completer);
 typedef void (*CBLDart_PredictiveModel_Unregistered)(void);
 
-typedef struct _CBLDart_PredictiveModel *CBLDart_PredictiveModel;
+typedef struct _CBLDart_PredictiveModel* CBLDart_PredictiveModel;
 
 CBLDART_EXPORT
 CBLDart_PredictiveModel CBLDart_PredictiveModel_New(
@@ -208,14 +208,14 @@ void CBLDart_PredictiveModel_Delete(CBLDart_PredictiveModel model);
 // === Blob
 
 CBLDART_EXPORT
-FLSliceResult CBLDart_CBLBlobReader_Read(CBLBlobReadStream *stream,
+FLSliceResult CBLDart_CBLBlobReader_Read(CBLBlobReadStream* stream,
                                          uint64_t bufferSize,
-                                         CBLError *outError);
+                                         CBLError* outError);
 
 // === Replicator
 
 struct CBLDart_ReplicationCollection {
-  CBLCollection *collection;
+  CBLCollection* collection;
   FLArray channels;
   FLArray documentIDs;
   CBLDart_AsyncCallback pushFilter;
@@ -224,39 +224,39 @@ struct CBLDart_ReplicationCollection {
 };
 
 struct CBLDart_ReplicatorConfiguration {
-  CBLDatabase *database;
-  CBLEndpoint *endpoint;
+  CBLDatabase* database;
+  CBLEndpoint* endpoint;
   CBLReplicatorType replicatorType;
   bool continuous;
   bool disableAutoPurge;
   unsigned maxAttempts;
   unsigned maxAttemptWaitTime;
   unsigned heartbeat;
-  CBLAuthenticator *authenticator;
-  CBLProxySettings *proxy;
+  CBLAuthenticator* authenticator;
+  CBLProxySettings* proxy;
   FLDict headers;
   bool acceptOnlySelfSignedServerCertificate;
-  FLSlice *pinnedServerCertificate;
-  FLSlice *trustedRootCertificates;
-  CBLDart_ReplicationCollection *collections;
+  FLSlice* pinnedServerCertificate;
+  FLSlice* trustedRootCertificates;
+  CBLDart_ReplicationCollection* collections;
   size_t collectionsCount;
 };
 
 CBLDART_EXPORT
-CBLReplicator *CBLDart_CBLReplicator_Create(
-    CBLDart_ReplicatorConfiguration *config, CBLError *errorOut);
+CBLReplicator* CBLDart_CBLReplicator_Create(
+    CBLDart_ReplicatorConfiguration* config, CBLError* errorOut);
 
 CBLDART_EXPORT
-void CBLDart_CBLReplicator_Release(CBLReplicator *replicator);
+void CBLDart_CBLReplicator_Release(CBLReplicator* replicator);
 
 CBLDART_EXPORT
-void CBLDart_CBLReplicator_AddChangeListener(const CBLDatabase *db,
-                                             CBLReplicator *replicator,
+void CBLDart_CBLReplicator_AddChangeListener(const CBLDatabase* db,
+                                             CBLReplicator* replicator,
                                              CBLDart_AsyncCallback listenerId);
 
 CBLDART_EXPORT
 void CBLDart_CBLReplicator_AddDocumentReplicationListener(
-    const CBLDatabase *db, CBLReplicator *replicator,
+    const CBLDatabase* db, CBLReplicator* replicator,
     CBLDart_AsyncCallback listenerId);
 
 // === UrlEndpointListener
@@ -264,37 +264,37 @@ void CBLDart_CBLReplicator_AddDocumentReplicationListener(
 #ifdef COUCHBASE_ENTERPRISE
 
 typedef void (*CBLDartExternalKeyPublicKeyData)(CBLDart_Completer completer,
-                                                void *output,
+                                                void* output,
                                                 size_t outputMaxLen,
-                                                size_t *outputLen);
+                                                size_t* outputLen);
 
 typedef void (*CBLDartExternalKeyDecrypt)(CBLDart_Completer completer,
-                                          FLSlice input, void *output,
+                                          FLSlice input, void* output,
                                           size_t outputMaxLen,
-                                          size_t *outputLen);
+                                          size_t* outputLen);
 
 typedef void (*CBLDartExternalKeySign)(
     CBLDart_Completer completer, CBLSignatureDigestAlgorithm digestAlgorithm,
-    FLSlice inputData, void *outSignature);
+    FLSlice inputData, void* outSignature);
 
-CBLDART_EXPORT CBLKeyPair *CBLDartKeyPair_CreateWithExternalKey(
+CBLDART_EXPORT CBLKeyPair* CBLDartKeyPair_CreateWithExternalKey(
     size_t keySizeInBits, Dart_Handle delegate,
     CBLDartExternalKeyPublicKeyData publicKeyData,
     CBLDartExternalKeyDecrypt decrypt, CBLDartExternalKeySign sign,
-    CBLError *outError);
+    CBLError* outError);
 
 typedef void (*CBLDartListenerPasswordAuthCallback)(CBLDart_Completer completer,
                                                     FLString username,
                                                     FLString password);
 
 CBLDART_EXPORT bool CBLDart_ListenerPasswordAuthCallbackTrampoline(
-    void *context, FLString username, FLString password);
+    void* context, FLString username, FLString password);
 
 typedef void (*CBLDartListenerCertAuthCallback)(CBLDart_Completer completer,
-                                                CBLCert *cert);
+                                                CBLCert* cert);
 
-CBLDART_EXPORT bool CBLDart_ListenerCertAuthCallbackTrampoline(void *context,
-                                                               CBLCert *cert);
+CBLDART_EXPORT bool CBLDart_ListenerCertAuthCallbackTrampoline(void* context,
+                                                               CBLCert* cert);
 #else
 
 // With these stubs the same symbol export files can be used for both

--- a/native/couchbase-lite-dart/include/Fleece+Dart.h
+++ b/native/couchbase-lite-dart/include/Fleece+Dart.h
@@ -11,10 +11,10 @@
 // === Slice ==================================================================
 
 CBLDART_EXPORT
-void CBLDart_FLSliceResult_RetainByBuf(void *buf);
+void CBLDart_FLSliceResult_RetainByBuf(void* buf);
 
 CBLDART_EXPORT
-void CBLDart_FLSliceResult_ReleaseByBuf(void *buf);
+void CBLDart_FLSliceResult_ReleaseByBuf(void* buf);
 
 // === Decoder ================================================================
 
@@ -23,17 +23,17 @@ void CBLDart_FLSliceResult_ReleaseByBuf(void *buf);
 struct KnownSharedKeys;
 
 CBLDART_EXPORT
-KnownSharedKeys *CBLDart_KnownSharedKeys_New();
+KnownSharedKeys* CBLDart_KnownSharedKeys_New();
 
 CBLDART_EXPORT
-void CBLDart_KnownSharedKeys_Delete(KnownSharedKeys *keys);
+void CBLDart_KnownSharedKeys_Delete(KnownSharedKeys* keys);
 
 struct CBLDart_LoadedDictKey {
   bool isKnownSharedKey;  // Whether the key has been seen before. For shared
                           // keys, stringBuf and stringSize are only set the
                           // first time the key is seen.
   int sharedKey;  // The id of the shared key or -1 if the key is not shared.
-  const void *stringBuf;  // The pointer to the start of the key string.
+  const void* stringBuf;  // The pointer to the start of the key string.
   size_t stringSize;      // The length of the key string.
   FLValue value;          // The Fleece value of the key.
 };
@@ -46,48 +46,48 @@ struct CBLDart_LoadedFLValue {
   bool asBool;
   int64_t asInt;
   double asDouble;
-  const void *stringBuf;
+  const void* stringBuf;
   size_t stringSize;
   FLSlice asData;
   FLValue value;
 };
 
 CBLDART_EXPORT
-void CBLDart_GetLoadedFLValue(FLValue value, CBLDart_LoadedFLValue *out);
+void CBLDart_GetLoadedFLValue(FLValue value, CBLDart_LoadedFLValue* out);
 
 CBLDART_EXPORT
 void CBLDart_FLArray_GetLoadedFLValue(FLArray array, uint32_t index,
-                                      CBLDart_LoadedFLValue *out);
+                                      CBLDart_LoadedFLValue* out);
 
 CBLDART_EXPORT
 void CBLDart_FLDict_GetLoadedFLValue(FLDict dict, FLString key,
-                                     CBLDart_LoadedFLValue *out);
+                                     CBLDart_LoadedFLValue* out);
 
 struct CBLDart_FLDictIterator;
 
 CBLDART_EXPORT
-CBLDart_FLDictIterator *CBLDart_FLDictIterator_Begin(
-    FLDict dict, KnownSharedKeys *knownSharedKeys,
-    CBLDart_LoadedDictKey *keyOut, CBLDart_LoadedFLValue *valueOut,
+CBLDart_FLDictIterator* CBLDart_FLDictIterator_Begin(
+    FLDict dict, KnownSharedKeys* knownSharedKeys,
+    CBLDart_LoadedDictKey* keyOut, CBLDart_LoadedFLValue* valueOut,
     bool deleteOnDone, bool preLoad);
 
 CBLDART_EXPORT
-void CBLDart_FLDictIterator_Delete(CBLDart_FLDictIterator *iterator);
+void CBLDart_FLDictIterator_Delete(CBLDart_FLDictIterator* iterator);
 
 CBLDART_EXPORT
-bool CBLDart_FLDictIterator_Next(CBLDart_FLDictIterator *iterator);
+bool CBLDart_FLDictIterator_Next(CBLDart_FLDictIterator* iterator);
 
 struct CBLDart_FLArrayIterator;
 
 CBLDART_EXPORT
-CBLDart_FLArrayIterator *CBLDart_FLArrayIterator_Begin(
-    FLArray array, CBLDart_LoadedFLValue *valueOut, bool deleteOnDone);
+CBLDart_FLArrayIterator* CBLDart_FLArrayIterator_Begin(
+    FLArray array, CBLDart_LoadedFLValue* valueOut, bool deleteOnDone);
 
 CBLDART_EXPORT
-void CBLDart_FLArrayIterator_Delete(CBLDart_FLArrayIterator *iterator);
+void CBLDart_FLArrayIterator_Delete(CBLDart_FLArrayIterator* iterator);
 
 CBLDART_EXPORT
-bool CBLDart_FLArrayIterator_Next(CBLDart_FLArrayIterator *iterator);
+bool CBLDart_FLArrayIterator_Next(CBLDart_FLArrayIterator* iterator);
 
 // === Encoder ================================================================
 

--- a/native/couchbase-lite-dart/src/AsyncCallback.cpp
+++ b/native/couchbase-lite-dart/src/AsyncCallback.cpp
@@ -10,31 +10,31 @@ namespace CBLDart {
 
 AsyncCallbackRegistry AsyncCallbackRegistry::instance;
 
-void AsyncCallbackRegistry::registerCallback(const AsyncCallback &callback) {
+void AsyncCallbackRegistry::registerCallback(const AsyncCallback& callback) {
   std::scoped_lock lock(mutex_);
   callbacks_.push_back(&callback);
 }
 
-void AsyncCallbackRegistry::unregisterCallback(const AsyncCallback &callback) {
+void AsyncCallbackRegistry::unregisterCallback(const AsyncCallback& callback) {
   std::scoped_lock lock(mutex_);
   callbacks_.erase(std::remove(callbacks_.begin(), callbacks_.end(), &callback),
                    callbacks_.end());
 }
 
 bool AsyncCallbackRegistry::callbackExists(
-    const AsyncCallback &callback) const {
+    const AsyncCallback& callback) const {
   std::scoped_lock lock(mutex_);
   return std::find(callbacks_.begin(), callbacks_.end(), &callback) !=
          callbacks_.end();
 }
 
-void AsyncCallbackRegistry::addBlockingCall(AsyncCallbackCall &call) {
+void AsyncCallbackRegistry::addBlockingCall(AsyncCallbackCall& call) {
   assert(call.isBlocking());
   std::scoped_lock lock(mutex_);
   blockingCalls_.push_back(&call);
 }
 
-bool AsyncCallbackRegistry::takeBlockingCall(AsyncCallbackCall &call) {
+bool AsyncCallbackRegistry::takeBlockingCall(AsyncCallbackCall& call) {
   std::scoped_lock lock(mutex_);
   auto position =
       std::find(blockingCalls_.begin(), blockingCalls_.end(), &call);
@@ -61,7 +61,7 @@ AsyncCallback::~AsyncCallback() {
   debugLog("deleted");
 }
 
-void AsyncCallback::setFinalizer(void *context, CallbackFinalizer finalizer) {
+void AsyncCallback::setFinalizer(void* context, CallbackFinalizer finalizer) {
   debugLog("setFinalizer");
   std::scoped_lock lock(mutex_);
   assert(!closed_);
@@ -89,7 +89,7 @@ void AsyncCallback::close() {
   {
     std::scoped_lock lock(mutex_);
     // Close calls which are executing or could be executed.
-    for (auto const &call : activeCalls_) {
+    for (auto const& call : activeCalls_) {
       call->close();
     }
   }
@@ -103,7 +103,7 @@ void AsyncCallback::close() {
   debugLog("closed");
 }
 
-void AsyncCallback::registerCall(AsyncCallbackCall &call) {
+void AsyncCallback::registerCall(AsyncCallbackCall& call) {
   assert(AsyncCallbackRegistry::instance.callbackExists(*this));
 
   std::scoped_lock lock(mutex_);
@@ -111,7 +111,7 @@ void AsyncCallback::registerCall(AsyncCallbackCall &call) {
   activeCalls_.push_back(&call);
 }
 
-void AsyncCallback::unregisterCall(AsyncCallbackCall &call) {
+void AsyncCallback::unregisterCall(AsyncCallbackCall& call) {
   std::scoped_lock lock(mutex_);
   activeCalls_.erase(
       std::remove(activeCalls_.begin(), activeCalls_.end(), &call),
@@ -123,14 +123,14 @@ void AsyncCallback::unregisterCall(AsyncCallbackCall &call) {
   }
 }
 
-bool AsyncCallback::sendRequest(Dart_CObject *request) {
+bool AsyncCallback::sendRequest(Dart_CObject* request) {
   // If the send port and therefore the callback is closed before the request
   // can be sent, this call returns false. This allows us to avoid calling this
   // function under a lock.
   return Dart_PostCObject_DL(sendPort_, request);
 }
 
-inline void AsyncCallback::debugLog(const char *message) {
+inline void AsyncCallback::debugLog(const char* message) {
 #ifdef DEBUG
   if (debug_) {
     printf("AsyncCallback #%d (native) -> %s\n", id_, message);
@@ -142,7 +142,7 @@ inline void AsyncCallback::debugLog(const char *message) {
 
 static std::string failureResult = "__ASYNC_CALLBACK_FAILED__";
 
-AsyncCallbackCall::AsyncCallbackCall(AsyncCallback &callback, bool isBlocking)
+AsyncCallbackCall::AsyncCallbackCall(AsyncCallback& callback, bool isBlocking)
     : callback_(callback) {
   callback_.registerCall(*this);
 
@@ -162,7 +162,7 @@ AsyncCallbackCall::~AsyncCallbackCall() {
   }
 }
 
-void AsyncCallbackCall::execute(Dart_CObject &arguments) {
+void AsyncCallbackCall::execute(Dart_CObject& arguments) {
   std::unique_lock lock(mutex_);
 
   assert(!isExecuted_);
@@ -194,7 +194,7 @@ void AsyncCallbackCall::execute(Dart_CObject &arguments) {
   CBLDart_CObject_SetPointer(&callPointer, isBlocking() ? this : nullptr);
 
   // The request is sent as an array.
-  Dart_CObject *requestValues[] = {&responsePort, &callPointer, &arguments};
+  Dart_CObject* requestValues[] = {&responsePort, &callPointer, &arguments};
 
   Dart_CObject request{};
   request.type = Dart_CObject_kArray;
@@ -233,7 +233,7 @@ void AsyncCallbackCall::execute(Dart_CObject &arguments) {
   debugLog("finished");
 }
 
-void AsyncCallbackCall::complete(Dart_CObject *result) {
+void AsyncCallbackCall::complete(Dart_CObject* result) {
   assert(result);
 
   if (!AsyncCallbackRegistry::instance.takeBlockingCall(*this)) {
@@ -294,20 +294,20 @@ void AsyncCallbackCall::close() {
 }
 
 void AsyncCallbackCall::messageHandler(Dart_Port dest_port_id,
-                                       Dart_CObject *response) {
+                                       Dart_CObject* response) {
   assert(response->type == Dart_CObject_kArray);
   assert(response->value.as_array.length == 2);
 
   auto callPointer = response->value.as_array.values[0];
   auto result = response->value.as_array.values[1];
 
-  AsyncCallbackCall &call = *reinterpret_cast<AsyncCallbackCall *>(
+  AsyncCallbackCall& call = *reinterpret_cast<AsyncCallbackCall*>(
       CBLDart_CObject_getIntValueAsInt64(callPointer));
 
   call.complete(result);
 }
 
-void AsyncCallbackCall::waitForCompletion(std::unique_lock<std::mutex> &lock) {
+void AsyncCallbackCall::waitForCompletion(std::unique_lock<std::mutex>& lock) {
   completedCv_.wait(lock, [this] { return isCompleted_; });
 
   if (didFail_) {
@@ -316,12 +316,12 @@ void AsyncCallbackCall::waitForCompletion(std::unique_lock<std::mutex> &lock) {
   }
 }
 
-bool AsyncCallbackCall::isFailureResult(Dart_CObject *result) {
+bool AsyncCallbackCall::isFailureResult(Dart_CObject* result) {
   return result->type == Dart_CObject_kString &&
          failureResult == result->value.as_string;
 }
 
-inline void AsyncCallbackCall::debugLog(const char *message) {
+inline void AsyncCallbackCall::debugLog(const char* message) {
 #ifdef DEBUG
   if (!callback_.debug_) {
     return;

--- a/native/couchbase-lite-dart/src/AsyncCallback.h
+++ b/native/couchbase-lite-dart/src/AsyncCallback.h
@@ -18,27 +18,27 @@ class AsyncCallbackRegistry {
  public:
   static AsyncCallbackRegistry instance;
 
-  void registerCallback(const AsyncCallback &callback);
+  void registerCallback(const AsyncCallback& callback);
 
-  void unregisterCallback(const AsyncCallback &callback);
+  void unregisterCallback(const AsyncCallback& callback);
 
-  bool callbackExists(const AsyncCallback &callback) const;
+  bool callbackExists(const AsyncCallback& callback) const;
 
-  void addBlockingCall(AsyncCallbackCall &call);
+  void addBlockingCall(AsyncCallbackCall& call);
 
-  bool takeBlockingCall(AsyncCallbackCall &call);
+  bool takeBlockingCall(AsyncCallbackCall& call);
 
  private:
   AsyncCallbackRegistry();
 
   mutable std::mutex mutex_;
-  std::vector<const AsyncCallback *> callbacks_;
-  std::vector<AsyncCallbackCall *> blockingCalls_;
+  std::vector<const AsyncCallback*> callbacks_;
+  std::vector<AsyncCallbackCall*> blockingCalls_;
 };
 
 // === AsyncCallback ==========================================================
 
-typedef void (*CallbackFinalizer)(void *context);
+typedef void (*CallbackFinalizer)(void* context);
 
 class AsyncCallback {
  public:
@@ -48,16 +48,16 @@ class AsyncCallback {
 
   uint32_t id() { return id_; };
 
-  void setFinalizer(void *context, CallbackFinalizer finalizer);
+  void setFinalizer(void* context, CallbackFinalizer finalizer);
   void close();
 
  private:
   friend class AsyncCallbackCall;
 
-  void registerCall(AsyncCallbackCall &call);
-  void unregisterCall(AsyncCallbackCall &call);
-  bool sendRequest(Dart_CObject *request);
-  inline void debugLog(const char *message);
+  void registerCall(AsyncCallbackCall& call);
+  void unregisterCall(AsyncCallbackCall& call);
+  bool sendRequest(Dart_CObject* request);
+  inline void debugLog(const char* message);
 
   uint32_t id_;
   bool debug_;
@@ -65,21 +65,21 @@ class AsyncCallback {
   std::condition_variable cv_;
   bool closed_ = false;
   Dart_Port sendPort_ = ILLEGAL_PORT;
-  void *finalizerContext_ = nullptr;
+  void* finalizerContext_ = nullptr;
   CallbackFinalizer finalizer_ = nullptr;
-  std::vector<AsyncCallbackCall *> activeCalls_;
+  std::vector<AsyncCallbackCall*> activeCalls_;
 };
 
 // === AsyncCallbackCall ======================================================
 
-typedef void(CallbackResultHandler)(Dart_CObject *);
+typedef void(CallbackResultHandler)(Dart_CObject*);
 
 class AsyncCallbackCall {
  public:
-  AsyncCallbackCall(AsyncCallback &callback, bool isBlocking = false);
+  AsyncCallbackCall(AsyncCallback& callback, bool isBlocking = false);
 
-  AsyncCallbackCall(AsyncCallback &callback,
-                    const std::function<CallbackResultHandler> &resultHandler)
+  AsyncCallbackCall(AsyncCallback& callback,
+                    const std::function<CallbackResultHandler>& resultHandler)
       : AsyncCallbackCall(callback, true) {
     resultHandler_ = &resultHandler;
   };
@@ -97,20 +97,20 @@ class AsyncCallbackCall {
     return isCompleted_;
   }
 
-  void execute(Dart_CObject &arguments);
-  void complete(Dart_CObject *result);
+  void execute(Dart_CObject& arguments);
+  void complete(Dart_CObject* result);
   void close();
 
  private:
-  static void messageHandler(Dart_Port dest_port_id, Dart_CObject *message);
+  static void messageHandler(Dart_Port dest_port_id, Dart_CObject* message);
 
-  void waitForCompletion(std::unique_lock<std::mutex> &lock);
-  bool isFailureResult(Dart_CObject *result);
-  inline void debugLog(const char *message);
+  void waitForCompletion(std::unique_lock<std::mutex>& lock);
+  bool isFailureResult(Dart_CObject* result);
+  inline void debugLog(const char* message);
 
   std::mutex mutex_;
-  AsyncCallback &callback_;
-  const std::function<CallbackResultHandler> *resultHandler_ = nullptr;
+  AsyncCallback& callback_;
+  const std::function<CallbackResultHandler>* resultHandler_ = nullptr;
   Dart_Port receivePort_ = ILLEGAL_PORT;
   bool isExecuted_ = false;
   bool isCompleted_ = false;

--- a/native/couchbase-lite-dart/src/CBL+Dart.cpp
+++ b/native/couchbase-lite-dart/src/CBL+Dart.cpp
@@ -17,9 +17,9 @@ bool CBLDart_CpuSupportsAVX2() { return CBLDart::CpuSupportsAVX2(); }
 static std::mutex initializeMutex;
 static bool initialized = false;
 
-CBLDartInitializeResult CBLDart_Initialize(void *dartInitializeDlData,
-                                           void *cblInitContext,
-                                           CBLError *errorOut) {
+CBLDartInitializeResult CBLDart_Initialize(void* dartInitializeDlData,
+                                           void* cblInitContext,
+                                           CBLError* errorOut) {
   std::scoped_lock lock(initializeMutex);
 
   if (initialized) {
@@ -29,8 +29,7 @@ CBLDartInitializeResult CBLDart_Initialize(void *dartInitializeDlData,
 
 #ifdef __ANDROID__
   // Initialize the Couchbase Lite library.
-  if (!CBL_Init(*reinterpret_cast<CBLInitContext *>(cblInitContext),
-                errorOut)) {
+  if (!CBL_Init(*reinterpret_cast<CBLInitContext*>(cblInitContext), errorOut)) {
     return CBLDartInitializeResult_kCBLInitError;
   }
 #endif
@@ -49,7 +48,7 @@ CBLDartInitializeResult CBLDart_Initialize(void *dartInitializeDlData,
 // === Async Callbacks
 
 #define ASYNC_CALLBACK_FROM_C(callback) \
-  reinterpret_cast<CBLDart::AsyncCallback *>(callback)
+  reinterpret_cast<CBLDart::AsyncCallback*>(callback)
 
 #define ASYNC_CALLBACK_TO_C(callback) \
   reinterpret_cast<CBLDart_AsyncCallback>(callback)
@@ -74,7 +73,7 @@ void CBLDart_AsyncCallback_CallForTest(CBLDart_AsyncCallback callback,
     argument__.type = Dart_CObject_kInt64;
     argument__.value.as_int64 = argument;
 
-    Dart_CObject *argsValues[] = {&argument__};
+    Dart_CObject* argsValues[] = {&argument__};
 
     Dart_CObject args{};
     args.type = Dart_CObject_kArray;
@@ -104,7 +103,7 @@ class Completer {
 }  // namespace CBLDart
 
 #define COMPLETER_FROM_C(completer) \
-  reinterpret_cast<CBLDart::Completer *>(completer)
+  reinterpret_cast<CBLDart::Completer*>(completer)
 
 #define COMPLETER_TO_C(completer) reinterpret_cast<CBLDart_Completer>(completer)
 
@@ -188,28 +187,28 @@ CBLDart_IsolateId CBLDart_GetCurrentIsolateId() { return currentIsolateId; }
  * When an object that has cloned a lock is destroyed it must call
  * `CBLDart_ReleaseDatabaseLock`.
  */
-static std::map<void *, std::shared_ptr<std::mutex>> databaseMutexes;
+static std::map<void*, std::shared_ptr<std::mutex>> databaseMutexes;
 static std::mutex databaseMutexesMutex;
 
-static void CBLDart_CreateDatabaseLock(CBLDatabase *database) {
+static void CBLDart_CreateDatabaseLock(CBLDatabase* database) {
   std::scoped_lock lock(databaseMutexesMutex);
   databaseMutexes[database] = std::make_shared<std::mutex>();
 }
 
-static void CBLDart_CloneDatabaseLock(const CBLDatabase *database,
-                                      void *owner) {
+static void CBLDart_CloneDatabaseLock(const CBLDatabase* database,
+                                      void* owner) {
   std::scoped_lock lock(databaseMutexesMutex);
-  assert(databaseMutexes.find(const_cast<CBLDatabase *>(database)) !=
+  assert(databaseMutexes.find(const_cast<CBLDatabase*>(database)) !=
          databaseMutexes.end());
-  databaseMutexes[owner] = databaseMutexes[const_cast<CBLDatabase *>(database)];
+  databaseMutexes[owner] = databaseMutexes[const_cast<CBLDatabase*>(database)];
 }
 
-static std::scoped_lock<std::mutex> CBLDart_AcquireDatabaseLock(void *owner) {
+static std::scoped_lock<std::mutex> CBLDart_AcquireDatabaseLock(void* owner) {
   std::scoped_lock lock(databaseMutexesMutex);
   return std::scoped_lock(*databaseMutexes[owner]);
 }
 
-static void CBLDart_ReleaseDatabaseLock(void *owner) {
+static void CBLDart_ReleaseDatabaseLock(void* owner) {
   std::scoped_lock lock(databaseMutexesMutex);
   databaseMutexes.erase(owner);
 }
@@ -218,8 +217,8 @@ static void CBLDart_ReleaseDatabaseLock(void *owner) {
 
 // Listeners that use this finalizer must use `CBLDart_CloneDatabaseLock`
 // to retain the database lock of the database they belong to.
-static void CBLDart_CBLListenerFinalizer(void *context) {
-  auto listenerToken = reinterpret_cast<CBLListenerToken *>(context);
+static void CBLDart_CBLListenerFinalizer(void* context) {
+  auto listenerToken = reinterpret_cast<CBLListenerToken*>(context);
   {
     // We acquire the database lock here to ensure that the database is not
     // closed while we are still executing.
@@ -232,9 +231,9 @@ static void CBLDart_CBLListenerFinalizer(void *context) {
 // === Log
 
 static std::shared_mutex loggingMutex;
-static CBLDart::AsyncCallback *logCallback = nullptr;
+static CBLDart::AsyncCallback* logCallback = nullptr;
 static CBLLogLevel logCallbackLevel = CBLLog_CallbackLevel();
-static CBLLogFileConfiguration *logFileConfig = nullptr;
+static CBLLogFileConfiguration* logFileConfig = nullptr;
 static bool logSentryBreadcrumbsEnabled = false;
 
 // Forward declarations for the logging functions.
@@ -285,7 +284,7 @@ static void CBLDart_CallDartLogCallback(CBLLogDomain domain, CBLLogLevel level,
   Dart_CObject message_{};
   CBLDart_CObject_SetFLString(&message_, message);
 
-  Dart_CObject *argsValues[] = {&domain_, &level_, &message_};
+  Dart_CObject* argsValues[] = {&domain_, &level_, &message_};
 
   Dart_CObject args{};
   args.type = Dart_CObject_kArray;
@@ -295,7 +294,7 @@ static void CBLDart_CallDartLogCallback(CBLLogDomain domain, CBLLogLevel level,
   CBLDart::AsyncCallbackCall(*logCallback).execute(args);
 }
 
-static void CBLDart_LogCallbackFinalizer(void *context) {
+static void CBLDart_LogCallbackFinalizer(void* context) {
   std::unique_lock lock(loggingMutex);
   logCallback = nullptr;
   CBLDart_UpdateEffectiveLogCallback();
@@ -329,8 +328,8 @@ void CBLDart_CBLLog_SetCallbackLevel(CBLLogLevel level) {
   CBLDart_UpdateEffectiveLogCallbackLevel();
 }
 
-bool CBLDart_CBLLog_SetFileConfig(CBLLogFileConfiguration *config,
-                                  CBLError *errorOut) {
+bool CBLDart_CBLLog_SetFileConfig(CBLLogFileConfiguration* config,
+                                  CBLError* errorOut) {
   std::unique_lock lock(loggingMutex);
 
   if (!config) {
@@ -373,7 +372,7 @@ bool CBLDart_CBLLog_SetFileConfig(CBLLogFileConfiguration *config,
   }
 }
 
-CBLLogFileConfiguration *CBLDart_CBLLog_GetFileConfig() {
+CBLLogFileConfiguration* CBLDart_CBLLog_GetFileConfig() {
   std::shared_lock lock(loggingMutex);
   return logFileConfig;
 }
@@ -392,7 +391,7 @@ static void CBLDart_CheckFileLogging() {
   });
 }
 
-static const char *CBLDart_LogDomainToSentryCategory(CBLLogDomain domain) {
+static const char* CBLDart_LogDomainToSentryCategory(CBLLogDomain domain) {
   switch (domain) {
     case kCBLLogDomainDatabase:
       return "cbl.db";
@@ -407,7 +406,7 @@ static const char *CBLDart_LogDomainToSentryCategory(CBLLogDomain domain) {
   }
 }
 
-static const char *CBLDart_LogLevelToSentryLevel(CBLLogLevel level) {
+static const char* CBLDart_LogLevelToSentryLevel(CBLLogLevel level) {
   switch (level) {
     case kCBLLogDebug:
     case kCBLLogVerbose:
@@ -464,15 +463,15 @@ bool CBLDart_CBLLog_SetSentryBreadcrumbs(bool enabled) {
  *
  * Used to ensure that databases are closed only once.
  */
-static std::vector<CBLDatabase *> openDatabases;
+static std::vector<CBLDatabase*> openDatabases;
 static std::mutex openDatabasesMutex;
 
-static void CBLDart_RegisterOpenDatabase(CBLDatabase *database) {
+static void CBLDart_RegisterOpenDatabase(CBLDatabase* database) {
   std::scoped_lock lock(openDatabasesMutex);
   openDatabases.push_back(database);
 }
 
-static bool CBLDart_UnregisterOpenDatabase(CBLDatabase *database) {
+static bool CBLDart_UnregisterOpenDatabase(CBLDatabase* database) {
   std::scoped_lock lock(openDatabasesMutex);
   // Check if the database is still open.
   auto it = std::find(openDatabases.begin(), openDatabases.end(), database);
@@ -486,8 +485,8 @@ static bool CBLDart_UnregisterOpenDatabase(CBLDatabase *database) {
   return true;
 }
 
-bool CBLDart_CBLDatabase_Close(CBLDatabase *database, bool andDelete,
-                               CBLError *errorOut) {
+bool CBLDart_CBLDatabase_Close(CBLDatabase* database, bool andDelete,
+                               CBLError* errorOut) {
   if (!CBLDart_UnregisterOpenDatabase(database)) {
     // Return early since the database has already been closed.
     return true;
@@ -532,17 +531,17 @@ CBLDart_CBLDatabaseConfiguration CBLDart_CBLDatabaseConfiguration_Default() {
 }
 
 bool CBLDart_CBL_CopyDatabase(FLString fromPath, FLString toName,
-                              const CBLDart_CBLDatabaseConfiguration *config,
-                              CBLError *outError) {
+                              const CBLDart_CBLDatabaseConfiguration* config,
+                              CBLError* outError) {
   auto config_ = config ? CBLDatabaseConfiguration_FromCBLDart(*config)
                         : CBLDatabaseConfiguration_Default();
 
   return CBL_CopyDatabase(fromPath, toName, &config_, outError);
 }
 
-CBLDatabase *CBLDart_CBLDatabase_Open(FLString name,
-                                      CBLDart_CBLDatabaseConfiguration *config,
-                                      CBLError *errorOut) {
+CBLDatabase* CBLDart_CBLDatabase_Open(FLString name,
+                                      CBLDart_CBLDatabaseConfiguration* config,
+                                      CBLError* errorOut) {
   CBLDart_CheckFileLogging();
 
   auto config_ = config ? CBLDatabaseConfiguration_FromCBLDart(*config)
@@ -558,13 +557,13 @@ CBLDatabase *CBLDart_CBLDatabase_Open(FLString name,
   return database;
 }
 
-void CBLDart_CBLDatabase_Release(CBLDatabase *database) {
+void CBLDart_CBLDatabase_Release(CBLDatabase* database) {
   CBLError error;
   if (!CBLDart_CBLDatabase_Close(database, false, &error)) {
     auto errorMessage = CBLError_Message(&error);
     CBL_Log(kCBLLogDomainDatabase, kCBLLogError,
             "Error closing database %p in Dart finalizer: %*.s", database,
-            static_cast<int>(errorMessage.size), (char *)errorMessage.buf);
+            static_cast<int>(errorMessage.size), (char*)errorMessage.buf);
     FLSliceResult_Release(errorMessage);
   }
   CBLDart_ReleaseDatabaseLock(database);
@@ -574,7 +573,7 @@ void CBLDart_CBLDatabase_Release(CBLDatabase *database) {
 // === Collection
 
 static void CBLDart_CollectionDocumentChangeListenerWrapper(
-    void *context, const CBLDocumentChange *change) {
+    void* context, const CBLDocumentChange* change) {
   auto callback = ASYNC_CALLBACK_FROM_C(context);
 
   Dart_CObject args{};
@@ -584,7 +583,7 @@ static void CBLDart_CollectionDocumentChangeListenerWrapper(
 }
 
 void CBLDart_CBLCollection_AddDocumentChangeListener(
-    const CBLDatabase *db, const CBLCollection *collection,
+    const CBLDatabase* db, const CBLCollection* collection,
     const FLString docID, CBLDart_AsyncCallback listener) {
   auto listenerToken = CBLCollection_AddDocumentChangeListener(
       collection, docID, CBLDart_CollectionDocumentChangeListenerWrapper,
@@ -597,7 +596,7 @@ void CBLDart_CBLCollection_AddDocumentChangeListener(
 }
 
 static void CBLDart_CollectionChangeListenerWrapper(
-    void *context, const CBLCollectionChange *change) {
+    void* context, const CBLCollectionChange* change) {
   auto callback = ASYNC_CALLBACK_FROM_C(context);
   auto numDocs = change->numDocs;
   auto docIDs = change->docIDs;
@@ -618,8 +617,8 @@ static void CBLDart_CollectionChangeListenerWrapper(
   CBLDart::AsyncCallbackCall(*callback).execute(args);
 }
 
-void CBLDart_CBLCollection_AddChangeListener(const CBLDatabase *db,
-                                             const CBLCollection *collection,
+void CBLDart_CBLCollection_AddChangeListener(const CBLDatabase* db,
+                                             const CBLCollection* collection,
                                              CBLDart_AsyncCallback listener) {
   auto listenerToken = CBLCollection_AddChangeListener(
       collection, CBLDart_CollectionChangeListenerWrapper, listener);
@@ -630,9 +629,9 @@ void CBLDart_CBLCollection_AddChangeListener(const CBLDatabase *db,
                                                 CBLDart_CBLListenerFinalizer);
 }
 
-bool CBLDart_CBLCollection_CreateIndex(CBLCollection *collection, FLString name,
+bool CBLDart_CBLCollection_CreateIndex(CBLCollection* collection, FLString name,
                                        CBLDart_CBLIndexSpec indexSpec,
-                                       CBLError *errorOut) {
+                                       CBLError* errorOut) {
   switch (indexSpec.type) {
     case kCBLDart_IndexTypeValue: {
       CBLValueIndexConfiguration config{};
@@ -659,7 +658,7 @@ bool CBLDart_CBLCollection_CreateIndex(CBLCollection *collection, FLString name,
       config.dimensions = indexSpec.dimensions;
       config.centroids = indexSpec.centroids;
       config.isLazy = indexSpec.isLazy;
-      config.encoding = static_cast<CBLVectorEncoding *>(indexSpec.encoding);
+      config.encoding = static_cast<CBLVectorEncoding*>(indexSpec.encoding);
       config.metric = static_cast<CBLDistanceMetric>(indexSpec.metric);
       config.minTrainingSize = indexSpec.minTrainingSize;
       config.maxTrainingSize = indexSpec.maxTrainingSize;
@@ -676,8 +675,8 @@ bool CBLDart_CBLCollection_CreateIndex(CBLCollection *collection, FLString name,
 
 // === Query
 
-static void CBLDart_QueryChangeListenerWrapper(void *context, CBLQuery *query,
-                                               CBLListenerToken *token) {
+static void CBLDart_QueryChangeListenerWrapper(void* context, CBLQuery* query,
+                                               CBLListenerToken* token) {
   auto callback = ASYNC_CALLBACK_FROM_C(context);
 
   Dart_CObject args{};
@@ -686,8 +685,8 @@ static void CBLDart_QueryChangeListenerWrapper(void *context, CBLQuery *query,
   CBLDart::AsyncCallbackCall(*callback).execute(args);
 }
 
-CBLListenerToken *CBLDart_CBLQuery_AddChangeListener(
-    const CBLDatabase *db, CBLQuery *query, CBLDart_AsyncCallback listener) {
+CBLListenerToken* CBLDart_CBLQuery_AddChangeListener(
+    const CBLDatabase* db, CBLQuery* query, CBLDart_AsyncCallback listener) {
   auto listenerToken = CBLQuery_AddChangeListener(
       query, CBLDart_QueryChangeListenerWrapper, listener);
 
@@ -729,7 +728,7 @@ struct PredictiveModel {
 }  // namespace CBLDart
 
 #define PREDICTIVE_MODEL_FROM_C(model) \
-  reinterpret_cast<CBLDart::PredictiveModel *>(model)
+  reinterpret_cast<CBLDart::PredictiveModel*>(model)
 
 #define PREDICTIVE_MODEL_TO_C(model) \
   reinterpret_cast<CBLDart_PredictiveModel>(model)
@@ -748,10 +747,10 @@ PredictiveModel::PredictiveModel(
       unregistered_(unregistered) {
   CBLPredictiveModel model{};
   model.context = this;
-  model.prediction = [](void *context, FLDict input) {
+  model.prediction = [](void* context, FLDict input) {
     return PREDICTIVE_MODEL_FROM_C(context)->prediction(input);
   };
-  model.unregistered = [](void *context) {
+  model.unregistered = [](void* context) {
     PREDICTIVE_MODEL_FROM_C(context)->unregistered();
   };
   CBL_RegisterPredictiveModel((FLString)name, model);
@@ -826,13 +825,13 @@ void CBLDart_PredictiveModel_Delete(CBLDart_PredictiveModel model) {
 
 // === Blob
 
-FLSliceResult CBLDart_CBLBlobReader_Read(CBLBlobReadStream *stream,
+FLSliceResult CBLDart_CBLBlobReader_Read(CBLBlobReadStream* stream,
                                          uint64_t bufferSize,
-                                         CBLError *outError) {
+                                         CBLError* outError) {
   auto bufferSize_t = static_cast<size_t>(bufferSize);
   auto buffer = FLSliceResult_New(bufferSize_t);
 
-  auto bytesRead = CBLBlobReader_Read(stream, const_cast<void *>(buffer.buf),
+  auto bytesRead = CBLBlobReader_Read(stream, const_cast<void*>(buffer.buf),
                                       bufferSize_t, outError);
 
   // Handle error
@@ -848,7 +847,7 @@ FLSliceResult CBLDart_CBLBlobReader_Read(CBLBlobReadStream *stream,
 
 // === Replicator
 
-typedef std::map<const CBLCollection *, CBLDart::AsyncCallback *>
+typedef std::map<const CBLCollection*, CBLDart::AsyncCallback*>
     ReplicatorCollectionCallbackMap;
 
 struct ReplicatorCallbackWrapperContext {
@@ -857,25 +856,25 @@ struct ReplicatorCallbackWrapperContext {
   ReplicatorCollectionCallbackMap conflictResolvers;
 
   void retainCollections() {
-    for (auto &pair : pushFilters) {
+    for (auto& pair : pushFilters) {
       CBLCollection_Retain(pair.first);
     }
-    for (auto &pair : pullFilters) {
+    for (auto& pair : pullFilters) {
       CBLCollection_Retain(pair.first);
     }
-    for (auto &pair : conflictResolvers) {
+    for (auto& pair : conflictResolvers) {
       CBLCollection_Retain(pair.first);
     }
   }
 
   void releaseCollections() {
-    for (auto &pair : pushFilters) {
+    for (auto& pair : pushFilters) {
       CBLCollection_Release(pair.first);
     }
-    for (auto &pair : pullFilters) {
+    for (auto& pair : pullFilters) {
       CBLCollection_Release(pair.first);
     }
-    for (auto &pair : conflictResolvers) {
+    for (auto& pair : conflictResolvers) {
       CBLCollection_Release(pair.first);
     }
   }
@@ -883,12 +882,12 @@ struct ReplicatorCallbackWrapperContext {
   ~ReplicatorCallbackWrapperContext() { releaseCollections(); }
 };
 
-static std::map<CBLReplicator *, ReplicatorCallbackWrapperContext *>
+static std::map<CBLReplicator*, ReplicatorCallbackWrapperContext*>
     replicatorCallbackWrapperContexts;
 static std::mutex replicatorCallbackWrapperContextsMutex;
 
-static bool CBLDart_ReplicatorFilterWrapper(CBLDart::AsyncCallback *callback,
-                                            CBLDocument *document,
+static bool CBLDart_ReplicatorFilterWrapper(CBLDart::AsyncCallback* callback,
+                                            CBLDocument* document,
                                             CBLDocumentFlags flags) {
   Dart_CObject document_{};
   CBLDart_CObject_SetPointer(&document_, document);
@@ -897,7 +896,7 @@ static bool CBLDart_ReplicatorFilterWrapper(CBLDart::AsyncCallback *callback,
   flags_.type = Dart_CObject_kInt32;
   flags_.value.as_int32 = flags;
 
-  Dart_CObject *argsValues[] = {&document_, &flags_};
+  Dart_CObject* argsValues[] = {&document_, &flags_};
 
   Dart_CObject args{};
   args.type = Dart_CObject_kArray;
@@ -906,7 +905,7 @@ static bool CBLDart_ReplicatorFilterWrapper(CBLDart::AsyncCallback *callback,
 
   bool decision;
 
-  auto resultHandler = [&](Dart_CObject *result) {
+  auto resultHandler = [&](Dart_CObject* result) {
     decision = result->value.as_bool;
   };
 
@@ -915,31 +914,31 @@ static bool CBLDart_ReplicatorFilterWrapper(CBLDart::AsyncCallback *callback,
   return decision;
 }
 
-static bool CBLDart_ReplicatorPushFilterWrapper(void *context,
-                                                CBLDocument *document,
+static bool CBLDart_ReplicatorPushFilterWrapper(void* context,
+                                                CBLDocument* document,
                                                 CBLDocumentFlags flags) {
   auto wrapperContext =
-      reinterpret_cast<ReplicatorCallbackWrapperContext *>(context);
+      reinterpret_cast<ReplicatorCallbackWrapperContext*>(context);
   auto collection = CBLDocument_Collection(document);
   return CBLDart_ReplicatorFilterWrapper(
       wrapperContext->pushFilters[collection], document, flags);
 }
 
-static bool CBLDart_ReplicatorPullFilterWrapper(void *context,
-                                                CBLDocument *document,
+static bool CBLDart_ReplicatorPullFilterWrapper(void* context,
+                                                CBLDocument* document,
                                                 CBLDocumentFlags flags) {
   auto wrapperContext =
-      reinterpret_cast<ReplicatorCallbackWrapperContext *>(context);
+      reinterpret_cast<ReplicatorCallbackWrapperContext*>(context);
   auto collection = CBLDocument_Collection(document);
   return CBLDart_ReplicatorFilterWrapper(
       wrapperContext->pullFilters[collection], document, flags);
 }
 
-static const CBLDocument *CBLDart_ReplicatorConflictResolverWrapper(
-    void *context, FLString documentID, const CBLDocument *localDocument,
-    const CBLDocument *remoteDocument) {
+static const CBLDocument* CBLDart_ReplicatorConflictResolverWrapper(
+    void* context, FLString documentID, const CBLDocument* localDocument,
+    const CBLDocument* remoteDocument) {
   auto wrapperContext =
-      reinterpret_cast<ReplicatorCallbackWrapperContext *>(context);
+      reinterpret_cast<ReplicatorCallbackWrapperContext*>(context);
   auto collection =
       CBLDocument_Collection(localDocument ? localDocument : remoteDocument);
   auto callback = wrapperContext->conflictResolvers[collection];
@@ -953,24 +952,24 @@ static const CBLDocument *CBLDart_ReplicatorConflictResolverWrapper(
   Dart_CObject remote{};
   CBLDart_CObject_SetPointer(&remote, remoteDocument);
 
-  Dart_CObject *argsValues[] = {&documentID_, &local, &remote};
+  Dart_CObject* argsValues[] = {&documentID_, &local, &remote};
 
   Dart_CObject args{};
   args.type = Dart_CObject_kArray;
   args.value.as_array.length = 3;
   args.value.as_array.values = argsValues;
 
-  const CBLDocument *decision;
+  const CBLDocument* decision;
   auto resolverThrewException = false;
 
-  auto resultHandler = [&](Dart_CObject *result) {
+  auto resultHandler = [&](Dart_CObject* result) {
     switch (result->type) {
       case Dart_CObject_kNull:
         decision = nullptr;
         break;
       case Dart_CObject_kInt32:
       case Dart_CObject_kInt64:
-        decision = reinterpret_cast<const CBLDocument *>(
+        decision = reinterpret_cast<const CBLDocument*>(
             CBLDart_CObject_getIntValueAsInt64(result));
         break;
 
@@ -1000,8 +999,8 @@ static const CBLDocument *CBLDart_ReplicatorConflictResolverWrapper(
   return decision;
 }
 
-CBLReplicator *CBLDart_CBLReplicator_Create(
-    CBLDart_ReplicatorConfiguration *config, CBLError *errorOut) {
+CBLReplicator* CBLDart_CBLReplicator_Create(
+    CBLDart_ReplicatorConfiguration* config, CBLError* errorOut) {
   CBLReplicatorConfiguration config_{};
   config_.endpoint = config->endpoint;
   config_.replicatorType =
@@ -1082,7 +1081,7 @@ CBLReplicator *CBLDart_CBLReplicator_Create(
   return replicator;
 }
 
-static void CBLDart_CBLReplicator_Release_Internal(CBLReplicator *replicator) {
+static void CBLDart_CBLReplicator_Release_Internal(CBLReplicator* replicator) {
   // Release the replicator.
   CBLReplicator_Release(replicator);
 
@@ -1094,7 +1093,7 @@ static void CBLDart_CBLReplicator_Release_Internal(CBLReplicator *replicator) {
   CBLDart_ReleaseDatabaseLock(replicator);
 }
 
-void CBLDart_CBLReplicator_Release(CBLReplicator *replicator) {
+void CBLDart_CBLReplicator_Release(CBLReplicator* replicator) {
   if (CBLReplicator_Status(replicator).activity == kCBLReplicatorStopped) {
     CBLDart_CBLReplicator_Release_Internal(replicator);
   } else {
@@ -1120,7 +1119,7 @@ void CBLDart_CBLReplicator_Release(CBLReplicator *replicator) {
 
 class ReplicatorStatus_CObject_Helper {
  public:
-  void init(const CBLReplicatorStatus *status) {
+  void init(const CBLReplicatorStatus* status) {
     assert(!errorMessageStr.buf);
 
     auto hasError = status->error.code != 0;
@@ -1164,11 +1163,11 @@ class ReplicatorStatus_CObject_Helper {
 
   ~ReplicatorStatus_CObject_Helper() { FLSliceResult_Release(errorMessageStr); }
 
-  Dart_CObject *cObject() { return &object; }
+  Dart_CObject* cObject() { return &object; }
 
  private:
   Dart_CObject object{};
-  Dart_CObject *objectValues[6];
+  Dart_CObject* objectValues[6];
   Dart_CObject activity{};
   Dart_CObject progressComplete{};
   Dart_CObject progressDocumentCount{};
@@ -1180,14 +1179,14 @@ class ReplicatorStatus_CObject_Helper {
 };
 
 static void CBLDart_Replicator_ChangeListenerWrapper(
-    void *context, CBLReplicator *replicator,
-    const CBLReplicatorStatus *status) {
+    void* context, CBLReplicator* replicator,
+    const CBLReplicatorStatus* status) {
   auto callback = ASYNC_CALLBACK_FROM_C(context);
 
   ReplicatorStatus_CObject_Helper cObjectStatus;
   cObjectStatus.init(status);
 
-  Dart_CObject *argsValues[] = {cObjectStatus.cObject()};
+  Dart_CObject* argsValues[] = {cObjectStatus.cObject()};
 
   Dart_CObject args{};
   args.type = Dart_CObject_kArray;
@@ -1197,8 +1196,8 @@ static void CBLDart_Replicator_ChangeListenerWrapper(
   CBLDart::AsyncCallbackCall(*callback).execute(args);
 }
 
-void CBLDart_CBLReplicator_AddChangeListener(const CBLDatabase *db,
-                                             CBLReplicator *replicator,
+void CBLDart_CBLReplicator_AddChangeListener(const CBLDatabase* db,
+                                             CBLReplicator* replicator,
                                              CBLDart_AsyncCallback listener) {
   auto listenerToken = CBLReplicator_AddChangeListener(
       replicator, CBLDart_Replicator_ChangeListenerWrapper, listener);
@@ -1211,7 +1210,7 @@ void CBLDart_CBLReplicator_AddChangeListener(const CBLDatabase *db,
 
 class ReplicatedDocument_CObject_Helper {
  public:
-  void init(const CBLReplicatedDocument *document) {
+  void init(const CBLReplicatedDocument* document) {
     assert(!errorMessageStr);
 
     auto hasError = document->error.code != 0;
@@ -1257,11 +1256,11 @@ class ReplicatedDocument_CObject_Helper {
     FLSliceResult_Release(errorMessageStr);
   }
 
-  Dart_CObject *cObject() { return &object; }
+  Dart_CObject* cObject() { return &object; }
 
  private:
   Dart_CObject object{};
-  Dart_CObject *objectValues[7];
+  Dart_CObject* objectValues[7];
   Dart_CObject id{};
   Dart_CObject flags{};
   Dart_CObject scope{};
@@ -1274,8 +1273,8 @@ class ReplicatedDocument_CObject_Helper {
 };
 
 static void CBLDart_Replicator_DocumentReplicationListenerWrapper(
-    void *context, CBLReplicator *replicator, bool isPush,
-    unsigned numDocuments, const CBLReplicatedDocument *documents) {
+    void* context, CBLReplicator* replicator, bool isPush,
+    unsigned numDocuments, const CBLReplicatedDocument* documents) {
   auto callback = ASYNC_CALLBACK_FROM_C(context);
 
   Dart_CObject isPush_{};
@@ -1284,7 +1283,7 @@ static void CBLDart_Replicator_DocumentReplicationListenerWrapper(
 
   std::vector<ReplicatedDocument_CObject_Helper> documentObjectHelpers(
       numDocuments);
-  std::vector<Dart_CObject *> documentObjects(numDocuments);
+  std::vector<Dart_CObject*> documentObjects(numDocuments);
 
   for (size_t i = 0; i < numDocuments; i++) {
     auto helper = &documentObjectHelpers[i];
@@ -1297,7 +1296,7 @@ static void CBLDart_Replicator_DocumentReplicationListenerWrapper(
   cObjectDocumentsArray.value.as_array.length = numDocuments;
   cObjectDocumentsArray.value.as_array.values = documentObjects.data();
 
-  Dart_CObject *argsValues[] = {&isPush_, &cObjectDocumentsArray};
+  Dart_CObject* argsValues[] = {&isPush_, &cObjectDocumentsArray};
 
   Dart_CObject args{};
   args.type = Dart_CObject_kArray;
@@ -1308,11 +1307,11 @@ static void CBLDart_Replicator_DocumentReplicationListenerWrapper(
 }
 
 void CBLDart_CBLReplicator_AddDocumentReplicationListener(
-    const CBLDatabase *db, CBLReplicator *replicator,
+    const CBLDatabase* db, CBLReplicator* replicator,
     CBLDart_AsyncCallback listener) {
   auto listenerToken = CBLReplicator_AddDocumentReplicationListener(
       replicator, CBLDart_Replicator_DocumentReplicationListenerWrapper,
-      (void *)listener);
+      (void*)listener);
 
   CBLDart_CloneDatabaseLock(db, listenerToken);
 
@@ -1337,36 +1336,36 @@ struct CBLDartExternalKeyCallbacks {
 
   ~CBLDartExternalKeyCallbacks() { Dart_DeletePersistentHandle_DL(delegate); }
 
-  static bool publicKeyData(void *externalKey, void *output,
-                            size_t outputMaxLen, size_t *outputLen) {
-    auto self = reinterpret_cast<CBLDartExternalKeyCallbacks *>(externalKey);
+  static bool publicKeyData(void* externalKey, void* output,
+                            size_t outputMaxLen, size_t* outputLen) {
+    auto self = reinterpret_cast<CBLDartExternalKeyCallbacks*>(externalKey);
     auto completer = CBLDart::Completer();
     self->_publicKeyData(COMPLETER_TO_C(&completer), output, outputMaxLen,
                          outputLen);
     return (bool)completer.wait();
   }
 
-  static bool decrypt(void *externalKey, FLSlice input, void *output,
-                      size_t outputMaxLen, size_t *outputLen) {
-    auto self = reinterpret_cast<CBLDartExternalKeyCallbacks *>(externalKey);
+  static bool decrypt(void* externalKey, FLSlice input, void* output,
+                      size_t outputMaxLen, size_t* outputLen) {
+    auto self = reinterpret_cast<CBLDartExternalKeyCallbacks*>(externalKey);
     auto completer = CBLDart::Completer();
     self->_decrypt(COMPLETER_TO_C(&completer), input, output, outputMaxLen,
                    outputLen);
     return (bool)completer.wait();
   }
 
-  static bool sign(void *externalKey,
+  static bool sign(void* externalKey,
                    CBLSignatureDigestAlgorithm digestAlgorithm,
-                   FLSlice inputData, void *outSignature) {
-    auto self = reinterpret_cast<CBLDartExternalKeyCallbacks *>(externalKey);
+                   FLSlice inputData, void* outSignature) {
+    auto self = reinterpret_cast<CBLDartExternalKeyCallbacks*>(externalKey);
     auto completer = CBLDart::Completer();
     self->_sign(COMPLETER_TO_C(&completer), digestAlgorithm, inputData,
                 outSignature);
     return (bool)completer.wait();
   }
 
-  static void free(void *externalKey) {
-    auto self = reinterpret_cast<CBLDartExternalKeyCallbacks *>(externalKey);
+  static void free(void* externalKey) {
+    auto self = reinterpret_cast<CBLDartExternalKeyCallbacks*>(externalKey);
     delete self;
   }
 
@@ -1377,11 +1376,11 @@ struct CBLDartExternalKeyCallbacks {
   CBLDartExternalKeySign _sign;
 };
 
-CBLKeyPair *CBLDartKeyPair_CreateWithExternalKey(
+CBLKeyPair* CBLDartKeyPair_CreateWithExternalKey(
     size_t keySizeInBits, Dart_Handle delegate,
     CBLDartExternalKeyPublicKeyData publicKeyData,
     CBLDartExternalKeyDecrypt decrypt, CBLDartExternalKeySign sign,
-    CBLError *outError) {
+    CBLError* outError) {
   auto callbacks =
       new CBLDartExternalKeyCallbacks(delegate, publicKeyData, decrypt, sign);
 
@@ -1400,7 +1399,7 @@ CBLKeyPair *CBLDartKeyPair_CreateWithExternalKey(
   return externalKey;
 }
 
-bool CBLDart_ListenerPasswordAuthCallbackTrampoline(void *context,
+bool CBLDart_ListenerPasswordAuthCallbackTrampoline(void* context,
                                                     FLString username,
                                                     FLString password) {
   auto callback = (CBLDartListenerPasswordAuthCallback)context;
@@ -1409,7 +1408,7 @@ bool CBLDart_ListenerPasswordAuthCallbackTrampoline(void *context,
   return (bool)completer.wait();
 }
 
-bool CBLDart_ListenerCertAuthCallbackTrampoline(void *context, CBLCert *cert) {
+bool CBLDart_ListenerCertAuthCallbackTrampoline(void* context, CBLCert* cert) {
   auto callback = (CBLDartListenerCertAuthCallback)context;
   auto completer = CBLDart::Completer();
   callback(COMPLETER_TO_C(&completer), cert);

--- a/native/couchbase-lite-dart/src/Fleece+Dart.cpp
+++ b/native/couchbase-lite-dart/src/Fleece+Dart.cpp
@@ -7,11 +7,11 @@
 
 // === Slice
 
-void CBLDart_FLSliceResult_RetainByBuf(void *buf) {
+void CBLDart_FLSliceResult_RetainByBuf(void* buf) {
   (void)FLSliceResult_Retain({buf, 0});
 }
 
-void CBLDart_FLSliceResult_ReleaseByBuf(void *buf) {
+void CBLDart_FLSliceResult_ReleaseByBuf(void* buf) {
   (void)FLSliceResult_Release({buf, 0});
 }
 
@@ -37,13 +37,13 @@ struct KnownSharedKeys {
   std::bitset<kMaxSharedKeys> _knownKeys;
 };
 
-KnownSharedKeys *CBLDart_KnownSharedKeys_New() { return new KnownSharedKeys; }
+KnownSharedKeys* CBLDart_KnownSharedKeys_New() { return new KnownSharedKeys; }
 
-void CBLDart_KnownSharedKeys_Delete(KnownSharedKeys *keys) { delete keys; }
+void CBLDart_KnownSharedKeys_Delete(KnownSharedKeys* keys) { delete keys; }
 
-static void CBLDart_GetLoadedDictKey(KnownSharedKeys *knownSharedKeys,
-                                     FLDictIterator *iterator,
-                                     CBLDart_LoadedDictKey *out) {
+static void CBLDart_GetLoadedDictKey(KnownSharedKeys* knownSharedKeys,
+                                     FLDictIterator* iterator,
+                                     CBLDart_LoadedDictKey* out) {
   auto key = out->value = FLDictIterator_GetKey(iterator);
 
   FLString string;
@@ -71,7 +71,7 @@ static void CBLDart_GetLoadedDictKey(KnownSharedKeys *knownSharedKeys,
   out->stringSize = string.size;
 }
 
-void CBLDart_GetLoadedFLValue(FLValue value, CBLDart_LoadedFLValue *out) {
+void CBLDart_GetLoadedFLValue(FLValue value, CBLDart_LoadedFLValue* out) {
   if (value) {
     out->exists = true;
   } else {
@@ -124,29 +124,29 @@ void CBLDart_GetLoadedFLValue(FLValue value, CBLDart_LoadedFLValue *out) {
 }
 
 void CBLDart_FLArray_GetLoadedFLValue(FLArray array, uint32_t index,
-                                      CBLDart_LoadedFLValue *out) {
+                                      CBLDart_LoadedFLValue* out) {
   auto value = FLArray_Get(array, index);
   CBLDart_GetLoadedFLValue(value, out);
 }
 
 void CBLDart_FLDict_GetLoadedFLValue(FLDict dict, FLString key,
-                                     CBLDart_LoadedFLValue *out) {
+                                     CBLDart_LoadedFLValue* out) {
   CBLDart_GetLoadedFLValue(FLDict_Get(dict, key), out);
 }
 
 struct CBLDart_FLDictIterator {
-  CBLDart_LoadedDictKey *_keyOut;
-  CBLDart_LoadedFLValue *_valueOut;
-  KnownSharedKeys *_knownSharedKeys;
+  CBLDart_LoadedDictKey* _keyOut;
+  CBLDart_LoadedFLValue* _valueOut;
+  KnownSharedKeys* _knownSharedKeys;
   bool _preLoad;
   FLDictIterator _iterator;
   bool _isDone;
   bool _deleteOnDone;
 };
 
-CBLDart_FLDictIterator *CBLDart_FLDictIterator_Begin(
-    FLDict dict, KnownSharedKeys *knownSharedKeys,
-    CBLDart_LoadedDictKey *keyOut, CBLDart_LoadedFLValue *valueOut,
+CBLDart_FLDictIterator* CBLDart_FLDictIterator_Begin(
+    FLDict dict, KnownSharedKeys* knownSharedKeys,
+    CBLDart_LoadedDictKey* keyOut, CBLDart_LoadedFLValue* valueOut,
     bool deleteOnDone, bool preLoad) {
   auto iterator = new CBLDart_FLDictIterator{};
   iterator->_keyOut = keyOut;
@@ -161,11 +161,11 @@ CBLDart_FLDictIterator *CBLDart_FLDictIterator_Begin(
   return iterator;
 }
 
-void CBLDart_FLDictIterator_Delete(CBLDart_FLDictIterator *iterator) {
+void CBLDart_FLDictIterator_Delete(CBLDart_FLDictIterator* iterator) {
   delete iterator;
 }
 
-bool CBLDart_FLDictIterator_Next(CBLDart_FLDictIterator *iterator) {
+bool CBLDart_FLDictIterator_Next(CBLDart_FLDictIterator* iterator) {
   auto dictIterator = &iterator->_iterator;
   auto value = FLDictIterator_GetValue(dictIterator);
   iterator->_isDone = value == nullptr;
@@ -198,13 +198,13 @@ bool CBLDart_FLDictIterator_Next(CBLDart_FLDictIterator *iterator) {
 }
 
 struct CBLDart_FLArrayIterator {
-  CBLDart_LoadedFLValue *_valueOut;
+  CBLDart_LoadedFLValue* _valueOut;
   FLArrayIterator _iterator;
   bool _deleteOnDone;
 };
 
-CBLDart_FLArrayIterator *CBLDart_FLArrayIterator_Begin(
-    FLArray array, CBLDart_LoadedFLValue *valueOut, bool deleteOnDone) {
+CBLDart_FLArrayIterator* CBLDart_FLArrayIterator_Begin(
+    FLArray array, CBLDart_LoadedFLValue* valueOut, bool deleteOnDone) {
   auto iterator = new CBLDart_FLArrayIterator{};
   iterator->_valueOut = valueOut;
   iterator->_deleteOnDone = deleteOnDone;
@@ -214,11 +214,11 @@ CBLDart_FLArrayIterator *CBLDart_FLArrayIterator_Begin(
   return iterator;
 }
 
-void CBLDart_FLArrayIterator_Delete(CBLDart_FLArrayIterator *iterator) {
+void CBLDart_FLArrayIterator_Delete(CBLDart_FLArrayIterator* iterator) {
   delete iterator;
 }
 
-bool CBLDart_FLArrayIterator_Next(CBLDart_FLArrayIterator *iterator) {
+bool CBLDart_FLArrayIterator_Next(CBLDart_FLArrayIterator* iterator) {
   auto arrayIterator = &iterator->_iterator;
   auto value = FLArrayIterator_GetValue(arrayIterator);
   if (value) {

--- a/native/couchbase-lite-dart/src/Sentry.cpp
+++ b/native/couchbase-lite-dart/src/Sentry.cpp
@@ -7,11 +7,11 @@
 #endif
 
 // Function typedefs
-typedef sentry_value_t (*sentry_value_new_string_t)(const char *value);
-typedef int (*sentry_value_set_by_key_t)(sentry_value_t value, const char *k,
+typedef sentry_value_t (*sentry_value_new_string_t)(const char* value);
+typedef int (*sentry_value_set_by_key_t)(sentry_value_t value, const char* k,
                                          sentry_value_t v);
-typedef sentry_value_t (*sentry_value_new_breadcrumb_t)(const char *type,
-                                                        const char *message);
+typedef sentry_value_t (*sentry_value_new_breadcrumb_t)(const char* type,
+                                                        const char* message);
 typedef void (*sentry_add_breadcrumb_t)(sentry_value_t breadcrumb);
 
 // Function pointers
@@ -61,17 +61,17 @@ bool CBLDart_InitSentryAPI() {
 }
 
 // Function definitions
-sentry_value_t sentry_value_new_string(const char *value) {
+sentry_value_t sentry_value_new_string(const char* value) {
   return sentry_value_new_string_fp(value);
 }
 
-int sentry_value_set_by_key(sentry_value_t value, const char *k,
+int sentry_value_set_by_key(sentry_value_t value, const char* k,
                             sentry_value_t v) {
   return sentry_value_set_by_key_fp(value, k, v);
 }
 
-sentry_value_t sentry_value_new_breadcrumb(const char *type,
-                                           const char *message) {
+sentry_value_t sentry_value_new_breadcrumb(const char* type,
+                                           const char* message) {
   return sentry_value_new_breadcrumb_fp(type, message);
 }
 

--- a/native/couchbase-lite-dart/src/Sentry.h
+++ b/native/couchbase-lite-dart/src/Sentry.h
@@ -73,7 +73,7 @@ typedef union sentry_value_u sentry_value_t;
 /**
  * Creates a new null terminated string.
  */
-SENTRY_API sentry_value_t sentry_value_new_string(const char *value);
+SENTRY_API sentry_value_t sentry_value_new_string(const char* value);
 
 /**
  * Sets a key to a value in the map.
@@ -81,7 +81,7 @@ SENTRY_API sentry_value_t sentry_value_new_string(const char *value);
  * This moves the ownership of the value into the map.  The caller does not
  * have to call `sentry_value_decref` on it.
  */
-SENTRY_API int sentry_value_set_by_key(sentry_value_t value, const char *k,
+SENTRY_API int sentry_value_set_by_key(sentry_value_t value, const char* k,
                                        sentry_value_t v);
 
 /**
@@ -91,8 +91,8 @@ SENTRY_API int sentry_value_set_by_key(sentry_value_t value, const char *k,
  *
  * Either parameter can be NULL in which case no such attributes is created.
  */
-SENTRY_API sentry_value_t sentry_value_new_breadcrumb(const char *type,
-                                                      const char *message);
+SENTRY_API sentry_value_t sentry_value_new_breadcrumb(const char* type,
+                                                      const char* message);
 
 /**
  * Adds the breadcrumb to be sent in case of an event.


### PR DESCRIPTION
Upgrades the clang-format GitHub Action from v4.14.0 to v4.16.0 and explicitly pins the clang-format version to 21 (the new default). The native C/C++ source files have been reformatted to comply with clang-format 21's pointer/reference alignment rules. All formatting changes are whitespace only.