### PR TITLE
chore: bump minimum SDK constraints to Dart 3.9.0 and Flutter 3.32.0

### DIFF
--- a/packages/benchmark/pubspec.yaml
+++ b/packages/benchmark/pubspec.yaml
@@ -1,7 +1,7 @@
 name: benchmark
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.9.0
 
 dependencies:
   benchmark_harness: ^2.3.1

--- a/packages/cbl/example/pubspec.yaml
+++ b/packages/cbl/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: cbl_example
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.9.0
 
 dependencies:
   cbl: ^3.6.0+2

--- a/packages/cbl/pubspec.yaml
+++ b/packages/cbl/pubspec.yaml
@@ -9,7 +9,7 @@ repository: https://github.com/cbl-dart/cbl-dart
 issue_tracker: https://github.com/cbl-dart/cbl-dart/issues
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.9.0
 
 dependencies:
   archive: '>=3.6.1 <5.0.0'

--- a/packages/cbl_dart/example/pubspec.yaml
+++ b/packages/cbl_dart/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: cbl_dart_example
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.9.0
 
 dependencies:
   cbl: ^3.6.0+2

--- a/packages/cbl_dart/pubspec.yaml
+++ b/packages/cbl_dart/pubspec.yaml
@@ -9,7 +9,7 @@ repository: https://github.com/cbl-dart/cbl-dart
 issue_tracker: https://github.com/cbl-dart/cbl-dart/issues
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.9.0
 
 dependencies:
   cbl: ^3.6.0+2

--- a/packages/cbl_e2e_tests/pubspec.yaml
+++ b/packages/cbl_e2e_tests/pubspec.yaml
@@ -2,7 +2,7 @@ name: cbl_e2e_tests
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.9.0
 
 dependencies:
   benchmark_harness: ^2.1.0

--- a/packages/cbl_e2e_tests_flutter/pubspec.yaml
+++ b/packages/cbl_e2e_tests_flutter/pubspec.yaml
@@ -3,8 +3,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.0.0
-  flutter: '>=3.0.0'
+  sdk: ^3.9.0
+  flutter: '>=3.32.0'
 
 dependencies:
   benchmark_harness: ^2.1.0

--- a/packages/cbl_e2e_tests_standalone_dart/pubspec.yaml
+++ b/packages/cbl_e2e_tests_standalone_dart/pubspec.yaml
@@ -2,7 +2,7 @@ name: cbl_e2e_tests_standalone_dart
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.9.0
 
 dependencies:
   benchmark_harness: ^2.1.0

--- a/packages/cbl_flutter/example/pubspec.yaml
+++ b/packages/cbl_flutter/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.9.0
 
 dependencies:
   cbl: ^3.6.0+2

--- a/packages/cbl_flutter/pubspec.yaml
+++ b/packages/cbl_flutter/pubspec.yaml
@@ -9,8 +9,8 @@ repository: https://github.com/cbl-dart/cbl-dart
 issue_tracker: https://github.com/cbl-dart/cbl-dart/issues
 
 environment:
-  sdk: ^3.0.0
-  flutter: '>=3.0.0'
+  sdk: ^3.9.0
+  flutter: '>=3.32.0'
 
 dependencies:
   cbl: ^3.6.0+2

--- a/packages/cbl_flutter_ce/pubspec.yaml
+++ b/packages/cbl_flutter_ce/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/cbl-dart/cbl-dart
 issue_tracker: https://github.com/cbl-dart/cbl-dart/issues
 
 environment:
-  sdk: ^3.0.0
-  flutter: '>=3.0.0'
+  sdk: ^3.9.0
+  flutter: '>=3.32.0'
 
 dependencies:
   cbl_flutter_install: 0.1.0+6

--- a/packages/cbl_flutter_ee/pubspec.yaml
+++ b/packages/cbl_flutter_ee/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/cbl-dart/cbl-dart
 issue_tracker: https://github.com/cbl-dart/cbl-dart/issues
 
 environment:
-  sdk: ^3.0.0
-  flutter: '>=3.0.0'
+  sdk: ^3.9.0
+  flutter: '>=3.32.0'
 
 dependencies:
   cbl_flutter_install: 0.1.0+6

--- a/packages/cbl_flutter_install/pubspec.yaml
+++ b/packages/cbl_flutter_install/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/cbl-dart/cbl-dart
 issue_tracker: https://github.com/cbl-dart/cbl-dart/issues
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.9.0
 
 executables:
   cbl_flutter_install:

--- a/packages/cbl_flutter_local/pubspec.yaml
+++ b/packages/cbl_flutter_local/pubspec.yaml
@@ -3,8 +3,8 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
-  flutter: '>=3.0.0'
+  sdk: ^3.9.0
+  flutter: '>=3.32.0'
 
 dependencies:
   cbl_flutter_platform_interface: ^3.1.6

--- a/packages/cbl_flutter_platform_interface/pubspec.yaml
+++ b/packages/cbl_flutter_platform_interface/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/cbl-dart/cbl-dart
 issue_tracker: https://github.com/cbl-dart/cbl-dart/issues
 
 environment:
-  sdk: ^3.0.0
-  flutter: '>=3.0.0'
+  sdk: ^3.9.0
+  flutter: '>=3.32.0'
 
 dependencies:
   cbl: ^3.6.0+2

--- a/packages/cbl_flutter_prebuilt/pubspec.yaml
+++ b/packages/cbl_flutter_prebuilt/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.9.0
 
 dependencies:
   cbl: ^3.6.0+2

--- a/packages/cbl_flutter_prebuilt_e2e_tests/pubspec.yaml
+++ b/packages/cbl_flutter_prebuilt_e2e_tests/pubspec.yaml
@@ -3,8 +3,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.0.0
-  flutter: '>=3.0.0'
+  sdk: ^3.9.0
+  flutter: '>=3.32.0'
 
 dependencies:
   cbl: ^3.6.0+2

--- a/packages/cbl_libcblite_api/pubspec.yaml
+++ b/packages/cbl_libcblite_api/pubspec.yaml
@@ -8,4 +8,4 @@ repository: https://github.com/cbl-dart/cbl-dart
 issue_tracker: https://github.com/cbl-dart/cbl-dart/issues
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.9.0

--- a/packages/cbl_libcblitedart_api/pubspec.yaml
+++ b/packages/cbl_libcblitedart_api/pubspec.yaml
@@ -8,4 +8,4 @@ repository: https://github.com/cbl-dart/cbl-dart
 issue_tracker: https://github.com/cbl-dart/cbl-dart/issues
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.9.0

--- a/packages/cbl_native_assets/pubspec.yaml
+++ b/packages/cbl_native_assets/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/cbl-dart/cbl-dart/issues
 publish_to: none
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.9.0
 
 dependencies:
   cbl: ^3.6.0+2

--- a/packages/cbl_sentry/example/pubspec.yaml
+++ b/packages/cbl_sentry/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.9.0
 
 dependencies:
   cbl: ^3.6.0+2

--- a/packages/cbl_sentry/pubspec.yaml
+++ b/packages/cbl_sentry/pubspec.yaml
@@ -8,7 +8,7 @@ repository: https://github.com/cbl-dart/cbl-dart
 issue_tracker: https://github.com/cbl-dart/cbl-dart/issues
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.9.0
 
 dependencies:
   cbl: ^3.6.0+2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cbl_dart_repo
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.9.0
 
 dev_dependencies:
   cbd:


### PR DESCRIPTION
## Summary
- Bumps Dart SDK constraint from `^3.0.0`/`^3.4.0` to `^3.9.0` across all 23 pubspec.yaml files
- Bumps Flutter constraint from `>=3.0.0` to `>=3.32.0` in 7 Flutter packages
- Prerequisite for migrating to melos 7.x (which requires Dart pub workspaces, available since Dart 3.9.0)

## Test plan
- [ ] CI passes (all jobs already use `stable`/`beta` channels which are above 3.9.0)
- [ ] `melos bootstrap` succeeds locally