### PR TITLE
ci: upgrade Windows runner to windows-2025

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -219,6 +219,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Disable Windows Defender
+        if: runner.os == 'Windows'
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        shell: powershell
 
       - name: Setup CMake and Ninja
         uses: lukka/get-cmake@latest
@@ -374,6 +378,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Disable Windows Defender
+        if: runner.os == 'Windows'
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        shell: powershell
 
       - name: Select Java 17
         if: ${{ matrix.os == 'Android' }}
@@ -496,6 +504,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Disable Windows Defender
+        if: runner.os == 'Windows'
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        shell: powershell
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -556,6 +568,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Disable Windows Defender
+        if: runner.os == 'Windows'
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        shell: powershell
 
       - name: Get CMake and Ninja
         uses: lukka/get-cmake@latest


### PR DESCRIPTION
Upgrade GitHub Actions Windows runner from windows-2022 to windows-2025 to improve CI performance. The windows-2025 image includes newer toolchains and improved I/O performance on Windows Server 2025.