### PR TITLE
fix: disable avoid_classes_with_only_static_members lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,10 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         dart: [stable, beta]
-    # continue-on-error: ${{ matrix.dart != 'stable' }}
-    # TODO: Require analysis to pass for stable once Dart SDK issue is fixed
-    # https://github.com/dart-lang/sdk/issues/56561
-    continue-on-error: true
+    continue-on-error: ${{ matrix.dart != 'stable' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -15,4 +15,5 @@ linter:
     prefer_asserts_with_message: false
     public_member_api_docs: false
     require_trailing_commas: false
+    avoid_classes_with_only_static_members: false
     avoid_redundant_argument_values: false

--- a/packages/cbl/lib/src/couchbase_lite.dart
+++ b/packages/cbl/lib/src/couchbase_lite.dart
@@ -12,7 +12,6 @@ export 'support/listener_token.dart' show ListenerToken;
 export 'support/resource.dart' show Resource, ClosableResource;
 export 'support/streams.dart' show AsyncListenStream;
 
-// ignore: avoid_classes_with_only_static_members
 /// Initializes global resources and configures global settings, such as
 /// logging.
 abstract final class CouchbaseLite {

--- a/packages/cbl/lib/src/database/database_configuration.dart
+++ b/packages/cbl/lib/src/database/database_configuration.dart
@@ -13,7 +13,6 @@ import '../support/edition.dart';
 import '../support/isolate.dart';
 import 'database.dart';
 
-// ignore: avoid_classes_with_only_static_members
 /// A key used to encrypt a [Database].
 ///
 /// {@template cbl.EncryptionKey.enterpriseFeature}

--- a/packages/cbl/lib/src/extension.dart
+++ b/packages/cbl/lib/src/extension.dart
@@ -3,7 +3,6 @@ import 'bindings.dart';
 
 final _binding = CBLBindings.instance.base;
 
-// ignore: avoid_classes_with_only_static_members
 /// Manage Couchbase Lite extensions.
 abstract final class Extension {
   /// Enables the vector search extension.

--- a/packages/cbl/lib/src/query/collation.dart
+++ b/packages/cbl/lib/src/query/collation.dart
@@ -8,7 +8,6 @@
 /// {@category Query Builder}
 abstract final class CollationInterface {}
 
-// ignore: avoid_classes_with_only_static_members
 /// Factory for creating collations.
 ///
 /// Couchbase Lite provides two types of collation: ASCII and Unicode. Without

--- a/packages/cbl/lib/src/query/data_source.dart
+++ b/packages/cbl/lib/src/query/data_source.dart
@@ -15,7 +15,6 @@ abstract final class DataSourceAs extends DataSourceInterface {
   DataSourceInterface as(String alias);
 }
 
-// ignore: avoid_classes_with_only_static_members
 /// Factory for creating data sources.
 ///
 /// {@category Query Builder}

--- a/packages/cbl/lib/src/query/expressions/array_expression.dart
+++ b/packages/cbl/lib/src/query/expressions/array_expression.dart
@@ -2,7 +2,6 @@ import 'array_expression_in.dart';
 import 'expression.dart';
 import 'variable_expression.dart';
 
-// ignore: avoid_classes_with_only_static_members
 /// Array expression.
 ///
 /// # Range predicates

--- a/packages/cbl/lib/src/query/expressions/expression.dart
+++ b/packages/cbl/lib/src/query/expressions/expression.dart
@@ -106,7 +106,6 @@ abstract interface class ExpressionInterface {
   ExpressionInterface collate(CollationInterface collation);
 }
 
-// ignore: avoid_classes_with_only_static_members
 /// Factory for creating expressions when building [Query]s through the
 /// [QueryBuilder].
 ///

--- a/packages/cbl/lib/src/query/expressions/meta.dart
+++ b/packages/cbl/lib/src/query/expressions/meta.dart
@@ -9,7 +9,6 @@ abstract final class MetaExpressionInterface implements ExpressionInterface {
   ExpressionInterface from(String alias);
 }
 
-// ignore: avoid_classes_with_only_static_members
 /// Factory for creating expressions of metadata properties of a document.
 ///
 /// {@category Query Builder}

--- a/packages/cbl/lib/src/query/function.dart
+++ b/packages/cbl/lib/src/query/function.dart
@@ -1,7 +1,6 @@
 import 'expressions/expression.dart';
 import 'prediction.dart';
 
-// ignore: avoid_classes_with_only_static_members
 /// Factory for creating function expressions.
 ///
 /// {@category Query Builder}

--- a/packages/cbl/lib/src/query/functions/array_function.dart
+++ b/packages/cbl/lib/src/query/functions/array_function.dart
@@ -1,6 +1,5 @@
 import '../expressions/expression.dart';
 
-// ignore: avoid_classes_with_only_static_members
 /// Factory for creating array function expressions.
 ///
 /// {@category Query Builder}

--- a/packages/cbl/lib/src/query/functions/full_text_function.dart
+++ b/packages/cbl/lib/src/query/functions/full_text_function.dart
@@ -1,6 +1,5 @@
 import '../expressions/expression.dart';
 
-// ignore: avoid_classes_with_only_static_members
 /// Factory for creating full-text search function expressions.
 ///
 /// {@category Query Builder}

--- a/packages/cbl/lib/src/query/index/index_builder.dart
+++ b/packages/cbl/lib/src/query/index/index_builder.dart
@@ -65,7 +65,6 @@ final class FullTextIndexItem {
   final ExpressionImpl _expression;
 }
 
-// ignore: avoid_classes_with_only_static_members
 /// Factor to create query indexes.
 ///
 /// {@category Query}

--- a/packages/cbl/lib/src/query/join.dart
+++ b/packages/cbl/lib/src/query/join.dart
@@ -16,7 +16,6 @@ abstract final class JoinOnInterface {
   JoinInterface on(ExpressionInterface expression);
 }
 
-// ignore: avoid_classes_with_only_static_members
 /// Factory for creating `JOIN` clauses.
 ///
 /// {@category Query Builder}

--- a/packages/cbl/lib/src/query/ordering.dart
+++ b/packages/cbl/lib/src/query/ordering.dart
@@ -16,7 +16,6 @@ abstract final class SortOrder extends OrderingInterface {
   OrderingInterface descending();
 }
 
-// ignore: avoid_classes_with_only_static_members
 /// Factory for ordering expressions of the `ORDER BY` clause of a query.
 ///
 /// {@category Query Builder}

--- a/packages/cbl/lib/src/query/prediction.dart
+++ b/packages/cbl/lib/src/query/prediction.dart
@@ -94,7 +94,6 @@ abstract interface class PredictiveModel {
   Dictionary? predict(Dictionary input);
 }
 
-// ignore: avoid_classes_with_only_static_members
 /// Manager for registering and unregistering [PredictiveModel]s.
 ///
 /// {@macro cbl.EncryptionKey.enterpriseFeature}

--- a/packages/cbl/lib/src/query/select_result.dart
+++ b/packages/cbl/lib/src/query/select_result.dart
@@ -23,7 +23,6 @@ abstract final class SelectResultFrom extends SelectResultInterface {
   SelectResultInterface from(String alias);
 }
 
-// ignore: avoid_classes_with_only_static_members
 /// Factory for select results.
 ///
 /// {@category Query Builder}

--- a/packages/cbl/lib/src/typed_data/helpers.dart
+++ b/packages/cbl/lib/src/typed_data/helpers.dart
@@ -6,7 +6,6 @@ import 'collection.dart';
 import 'conversion.dart';
 import 'typed_object.dart';
 
-// ignore: avoid_classes_with_only_static_members
 /// Helper functions for use by generated code.
 ///
 /// @nodoc

--- a/packages/cbl_dart/lib/cbl_dart.dart
+++ b/packages/cbl_dart/lib/cbl_dart.dart
@@ -11,7 +11,6 @@ import 'src/acquire_libraries.dart';
 
 export 'package:cbl/src/install.dart' show Edition;
 
-// ignore: avoid_classes_with_only_static_members
 /// Initializes global resources and configures global settings, such as
 /// logging, for usage of Couchbase Lite in pure Dart apps.
 abstract final class CouchbaseLiteDart {

--- a/packages/cbl_flutter/lib/cbl_flutter.dart
+++ b/packages/cbl_flutter/lib/cbl_flutter.dart
@@ -10,7 +10,6 @@ import 'package:cbl_flutter_platform_interface/cbl_flutter_platform_interface.da
 import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
 
-// ignore: avoid_classes_with_only_static_members
 /// Initializes global resources and configures global settings, such as
 /// logging, for usage of Couchbase Lite in Flutter apps.
 abstract final class CouchbaseLiteFlutter {

--- a/packages/cbl_flutter_local/lib/cbl_flutter_local.dart
+++ b/packages/cbl_flutter_local/lib/cbl_flutter_local.dart
@@ -1,7 +1,6 @@
 import 'package:cbl_flutter_platform_interface/cbl_flutter_platform_interface.dart';
 import 'package:cbl_flutter_platform_interface/standard_cbl_flutter_platform.dart';
 
-// ignore: avoid_classes_with_only_static_members
 abstract final class CblFlutterLocal {
   static void registerWith() {
     CblFlutterPlatform.instance = StandardCblFlutterPlatform(

--- a/packages/cbl_native_assets/lib/cbl_native_assets.dart
+++ b/packages/cbl_native_assets/lib/cbl_native_assets.dart
@@ -9,7 +9,6 @@ import 'package:cbl/src/bindings/cblitedart_native_assets_bridge.dart';
 import 'package:cbl/src/support/isolate.dart';
 import 'package:cbl/src/support/tracing.dart';
 
-// ignore: avoid_classes_with_only_static_members
 /// Initializes global resources and configures global settings, such as
 /// logging, for usage of Couchbase Lite..
 abstract final class CouchbaseLiteNativeAssets {


### PR DESCRIPTION
Fixes CI failure in the analyze beta SDK job. The Dart beta SDK now flags `abstract final` classes with only static members, a deliberate pattern throughout the codebase for static utility classes.

Changes:
- Disable `avoid_classes_with_only_static_members` lint in analysis_options.yaml
- Remove 21 now-unnecessary `// ignore:` comments from source files
- Restore `continue-on-error` to only apply to beta SDK (issue #56561 is resolved)