### PR TITLE
feat: add typed filters and resolvers to CollectionConfiguration

### DIFF
--- a/packages/cbl/lib/src/replication/common.dart
+++ b/packages/cbl/lib/src/replication/common.dart
@@ -55,5 +55,9 @@ Future<(ID, Map<IC, CollectionConfiguration>)> resolveReplicatorCollections<
     collections = config.collections.cast<IC, CollectionConfiguration>();
   }
 
-  return (database, collections);
+  final adapter = (database as DatabaseBase).typedDataAdapter;
+  final resolvedCollections = collections.map(
+    (collection, config) => MapEntry(collection, config.resolve(adapter)),
+  );
+  return (database, resolvedCollections);
 }

--- a/packages/cbl/lib/src/replication/configuration.dart
+++ b/packages/cbl/lib/src/replication/configuration.dart
@@ -83,8 +83,11 @@ final class CollectionConfiguration {
     this.channels,
     this.documentIds,
     this.pushFilter,
+    this.typedPushFilter,
     this.pullFilter,
+    this.typedPullFilter,
     this.conflictResolver,
+    this.typedConflictResolver,
   });
 
   /// Creates a replication configuration for a [Collection] from another
@@ -93,8 +96,11 @@ final class CollectionConfiguration {
     : channels = config.channels,
       documentIds = config.documentIds,
       pushFilter = config.pushFilter,
+      typedPushFilter = config.typedPushFilter,
       pullFilter = config.pullFilter,
-      conflictResolver = config.conflictResolver;
+      typedPullFilter = config.typedPullFilter,
+      conflictResolver = config.conflictResolver,
+      typedConflictResolver = config.typedConflictResolver;
 
   /// A set of Sync Gateway channel names to pull from.
   ///
@@ -116,17 +122,38 @@ final class CollectionConfiguration {
   /// Only documents for which the function returns `true` are replicated.
   ReplicationFilter? pushFilter;
 
+  /// Filter for validating whether the documents can be pushed to the remote
+  /// endpoint, which receives typed document instances.
+  ///
+  /// Only documents for which the function returns `true` are replicated.
+  @experimental
+  TypedReplicationFilter? typedPushFilter;
+
   /// Filter for validating whether the [Document]s can be pulled from the
   /// remote endpoint.
   ///
   /// Only documents for which the function returns `true` are replicated.
   ReplicationFilter? pullFilter;
 
+  /// Filter for validating whether the documents can be pulled from the remote
+  /// endpoint, which receives typed document instances.
+  ///
+  /// Only documents for which the function returns `true` are replicated.
+  @experimental
+  TypedReplicationFilter? typedPullFilter;
+
   /// A custom conflict resolver.
   ///
   /// If this value is not set, or set to `null`, the default conflict resolver
   /// will be applied.
   ConflictResolver? conflictResolver;
+
+  /// A custom conflict resolver, which receives typed document instances.
+  ///
+  /// If this value is not set, or set to `null`, the default conflict resolver
+  /// will be applied.
+  @experimental
+  TypedConflictResolver? typedConflictResolver;
 
   @override
   String toString() => [
@@ -135,8 +162,11 @@ final class CollectionConfiguration {
       if (channels != null) 'channels: $channels',
       if (documentIds != null) 'documentIds: $documentIds',
       if (pushFilter != null) 'PUSH-FILTER',
+      if (typedPushFilter != null) 'TYPED-PUSH-FILTER',
       if (pullFilter != null) 'PULL-FILTER',
+      if (typedPullFilter != null) 'TYPED-PULL-FILTER',
       if (conflictResolver != null) 'CUSTOM-CONFLICT-RESOLVER',
+      if (typedConflictResolver != null) 'TYPED-CUSTOM-CONFLICT-RESOLVER',
     ].join(', '),
     ')',
   ].join();
@@ -165,12 +195,15 @@ final class ReplicatorConfiguration {
     this.documentIds,
     @Deprecated('Use CollectionConfiguration.pushFilter instead.')
     this.pushFilter,
+    @Deprecated('Use CollectionConfiguration.typedPushFilter instead.')
     this.typedPushFilter,
     @Deprecated('Use CollectionConfiguration.pullFilter instead.')
     this.pullFilter,
+    @Deprecated('Use CollectionConfiguration.typedPullFilter instead.')
     this.typedPullFilter,
     @Deprecated('Use CollectionConfiguration.conflictResolver instead.')
     this.conflictResolver,
+    @Deprecated('Use CollectionConfiguration.typedConflictResolver instead.')
     this.typedConflictResolver,
     this.enableAutoPurge = true,
     this.acceptParentDomainCookies = false,
@@ -297,7 +330,7 @@ final class ReplicatorConfiguration {
   /// endpoint, which receives typed document instances.
   ///
   /// Only documents for which the function returns `true` are replicated.
-  @experimental
+  @Deprecated('Use CollectionConfiguration.typedPushFilter instead.')
   TypedReplicationFilter? typedPushFilter;
 
   /// Filter for validating whether the [Document]s can be pulled from the
@@ -311,7 +344,7 @@ final class ReplicatorConfiguration {
   /// endpoint, which receives typed document instances.
   ///
   /// Only documents for which the function returns `true` are replicated.
-  @experimental
+  @Deprecated('Use CollectionConfiguration.typedPullFilter instead.')
   TypedReplicationFilter? typedPullFilter;
 
   /// A custom conflict resolver.
@@ -325,7 +358,7 @@ final class ReplicatorConfiguration {
   ///
   /// If this value is not set, or set to `null`, the default conflict resolver
   /// will be applied.
-  @experimental
+  @Deprecated('Use CollectionConfiguration.typedConflictResolver instead.')
   TypedConflictResolver? typedConflictResolver;
 
   /// Whether to automatically purge a document when the user looses access to
@@ -574,6 +607,36 @@ extension InternalReplicatorConfiguration on ReplicatorConfiguration {
             'CollectionConfiguration.',
       );
     }
+  }
+}
+
+extension InternalCollectionConfiguration on CollectionConfiguration {
+  /// Returns a copy with typed fields combined into untyped fields.
+  CollectionConfiguration resolve(TypedDataAdapter? adapter) {
+    if (typedPushFilter == null &&
+        typedPullFilter == null &&
+        typedConflictResolver == null) {
+      return this;
+    }
+    return CollectionConfiguration(
+      channels: channels,
+      documentIds: documentIds,
+      pushFilter: combineReplicationFilters(
+        pushFilter,
+        typedPushFilter,
+        adapter,
+      ),
+      pullFilter: combineReplicationFilters(
+        pullFilter,
+        typedPullFilter,
+        adapter,
+      ),
+      conflictResolver: combineConflictResolvers(
+        conflictResolver,
+        typedConflictResolver,
+        adapter,
+      ),
+    );
   }
 }
 

--- a/packages/cbl_e2e_tests/lib/src/replication/configuration_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/replication/configuration_test.dart
@@ -16,6 +16,126 @@ import '../utils/matchers.dart';
 void main() {
   setupTestBinding();
 
+  group('CollectionConfiguration', () {
+    test('defaults', () {
+      final config = CollectionConfiguration();
+
+      expect(config.channels, isNull);
+      expect(config.documentIds, isNull);
+      expect(config.pushFilter, isNull);
+      expect(config.typedPushFilter, isNull);
+      expect(config.pullFilter, isNull);
+      expect(config.typedPullFilter, isNull);
+      expect(config.conflictResolver, isNull);
+      expect(config.typedConflictResolver, isNull);
+    });
+
+    test('from', () {
+      final source = CollectionConfiguration(
+        channels: ['A'],
+        documentIds: ['ID'],
+        pushFilter: (document, flags) => true,
+        typedPushFilter: (document, flags) => true,
+        pullFilter: (document, flags) => true,
+        typedPullFilter: (document, flags) => true,
+        conflictResolver: ConflictResolver.from((_) => null),
+        typedConflictResolver: TypedConflictResolver.from((_) => null),
+      );
+
+      final copy = CollectionConfiguration.from(source);
+
+      expect(copy.channels, source.channels);
+      expect(copy.documentIds, source.documentIds);
+      expect(copy.pushFilter, source.pushFilter);
+      expect(copy.typedPushFilter, source.typedPushFilter);
+      expect(copy.pullFilter, source.pullFilter);
+      expect(copy.typedPullFilter, source.typedPullFilter);
+      expect(copy.conflictResolver, source.conflictResolver);
+      expect(copy.typedConflictResolver, source.typedConflictResolver);
+    });
+
+    test('toString', () {
+      expect(CollectionConfiguration().toString(), 'CollectionConfiguration()');
+
+      expect(
+        CollectionConfiguration(
+          channels: ['A'],
+          documentIds: ['ID'],
+          pushFilter: (document, flags) => true,
+          typedPushFilter: (document, flags) => true,
+          pullFilter: (document, flags) => true,
+          typedPullFilter: (document, flags) => true,
+          conflictResolver: ConflictResolver.from((_) => null),
+          typedConflictResolver: TypedConflictResolver.from((_) => null),
+        ).toString(),
+        'CollectionConfiguration('
+        'channels: [A], '
+        'documentIds: [ID], '
+        'PUSH-FILTER, '
+        'TYPED-PUSH-FILTER, '
+        'PULL-FILTER, '
+        'TYPED-PULL-FILTER, '
+        'CUSTOM-CONFLICT-RESOLVER, '
+        // ignore: missing_whitespace_between_adjacent_strings
+        'TYPED-CUSTOM-CONFLICT-RESOLVER'
+        ')',
+      );
+    });
+
+    group('resolve', () {
+      test('returns same instance when no typed fields are set', () {
+        final config = CollectionConfiguration(
+          channels: ['A'],
+          pushFilter: (document, flags) => true,
+        );
+        final resolved = config.resolve(null);
+        expect(identical(resolved, config), isTrue);
+      });
+
+      test('combines typed push filter', () {
+        final adapter = TypedDataRegistry();
+        final config = CollectionConfiguration(
+          typedPushFilter: (document, flags) => true,
+        );
+        final resolved = config.resolve(adapter);
+        expect(resolved.pushFilter, isNotNull);
+        expect(resolved.typedPushFilter, isNull);
+      });
+
+      test('combines typed pull filter', () {
+        final adapter = TypedDataRegistry();
+        final config = CollectionConfiguration(
+          typedPullFilter: (document, flags) => true,
+        );
+        final resolved = config.resolve(adapter);
+        expect(resolved.pullFilter, isNotNull);
+        expect(resolved.typedPullFilter, isNull);
+      });
+
+      test('combines typed conflict resolver', () {
+        final adapter = TypedDataRegistry();
+        final config = CollectionConfiguration(
+          typedConflictResolver: TypedConflictResolver.from((_) => null),
+        );
+        final resolved = config.resolve(adapter);
+        expect(resolved.conflictResolver, isNotNull);
+        expect(resolved.typedConflictResolver, isNull);
+      });
+
+      test('preserves channels and documentIds', () {
+        final adapter = TypedDataRegistry();
+        final config = CollectionConfiguration(
+          channels: ['A', 'B'],
+          documentIds: ['ID1'],
+          typedPushFilter: (document, flags) => true,
+        );
+        final resolved = config.resolve(adapter);
+        expect(resolved.channels, ['A', 'B']);
+        expect(resolved.documentIds, ['ID1']);
+      });
+    });
+  });
+
   group('Configuration', () {
     test('defaults', () {
       final config = ReplicatorConfiguration(

--- a/packages/cbl_e2e_tests/lib/src/replication/replicator_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/replication/replicator_test.dart
@@ -310,6 +310,57 @@ void main() {
       expect(idsInPullDb, isNot(contains(docB.internal.id)));
     });
 
+    apiTest('use typedPushFilter in CollectionConfiguration to filter pushed '
+        'documents', () async {
+      final pushDb = await openTestDatabase(
+        name: 'Push',
+        typedDataAdapter: testAdapter,
+      );
+      final pullDb = await openTestDatabase(
+        name: 'Pull',
+        typedDataAdapter: testAdapter,
+      );
+
+      final docA = MutableTestTypedDoc();
+      await pushDb.saveTypedDocument(docA).withConcurrencyControl();
+      final docB = MutableTestTypedDoc();
+      await pushDb.saveTypedDocument(docB).withConcurrencyControl();
+
+      final pushConfig =
+          ReplicatorConfiguration(
+            target: UrlEndpoint(syncGatewayReplicationUrl),
+            replicatorType: ReplicatorType.push,
+            authenticator: janeAuthenticator,
+          )..addCollection(
+            await pushDb.defaultCollection,
+            CollectionConfiguration(
+              typedPushFilter: expectAsync2((document, flags) {
+                expect(flags, isEmpty);
+                expect(document, isA<TestTypedDoc>());
+                final doc = document as TestTypedDoc;
+                expect(
+                  doc.internal.id,
+                  anyOf(docA.internal.id, docB.internal.id),
+                );
+                return docA.internal.id == doc.internal.id;
+              }, count: 2),
+            ),
+          );
+      final pusher = await Replicator.create(pushConfig);
+      addTearDown(pusher.close);
+      await pusher.replicateOneShot();
+
+      final puller = await pullDb.createTestReplicator(
+        replicatorType: ReplicatorType.pull,
+      );
+      addTearDown(puller.close);
+      await puller.replicateOneShot();
+
+      final idsInPullDb = await pullDb.getAllIds();
+      expect(idsInPullDb, contains(docA.internal.id));
+      expect(idsInPullDb, isNot(contains(docB.internal.id)));
+    });
+
     apiTest('pushFilter exception handling', () async {
       Object? uncaughtError;
       await runZonedGuarded(
@@ -415,6 +466,57 @@ void main() {
           max: -1,
         ),
       );
+      addTearDown(puller.close);
+      await puller.replicateOneShot();
+
+      final idsInPullDb = await pullDb.getAllIds();
+      expect(idsInPullDb, contains(docA.internal.id));
+      expect(idsInPullDb, isNot(contains(docB.internal.id)));
+    });
+
+    apiTest('use typedPullFilter in CollectionConfiguration to filter pulled '
+        'documents', () async {
+      final pushDb = await openTestDatabase(
+        name: 'Push',
+        typedDataAdapter: testAdapter,
+      );
+      final pullDb = await openTestDatabase(
+        name: 'Pull',
+        typedDataAdapter: testAdapter,
+      );
+
+      final docA = MutableTestTypedDoc();
+      await pushDb.saveTypedDocument(docA).withConcurrencyControl();
+      final docB = MutableTestTypedDoc();
+      await pushDb.saveTypedDocument(docB).withConcurrencyControl();
+
+      final pusher = await pushDb.createTestReplicator(
+        replicatorType: ReplicatorType.push,
+      );
+      addTearDown(pusher.close);
+      await pusher.replicateOneShot();
+
+      final pullConfig =
+          ReplicatorConfiguration(
+            target: UrlEndpoint(syncGatewayReplicationUrl),
+            replicatorType: ReplicatorType.pull,
+            authenticator: janeAuthenticator,
+          )..addCollection(
+            await pullDb.defaultCollection,
+            CollectionConfiguration(
+              typedPullFilter: expectAsync2(
+                (document, flags) {
+                  expect(flags, isEmpty);
+                  expect(document, isA<TestTypedDoc>());
+                  final doc = document as TestTypedDoc;
+                  return docA.internal.id == doc.internal.id;
+                },
+                count: 2,
+                max: -1,
+              ),
+            ),
+          );
+      final puller = await Replicator.create(pullConfig);
       addTearDown(puller.close);
       await puller.replicateOneShot();
 
@@ -574,6 +676,64 @@ void main() {
 
       expect(await dbA.getTestDocumentOrNull(), isTestDocument('DB-B-1'));
     });
+
+    apiTest(
+      'custom typed conflict resolver in CollectionConfiguration',
+      () async {
+        // Create document in db A
+        // Sync db A with server
+        // Sync db B with server
+        // Change doc in db A
+        // Change doc in db B
+        // Sync db B with server
+        // Sync db A with server
+        // => Conflict in db A
+
+        final dbA = await openTestDatabase(
+          name: 'A',
+          typedDataAdapter: testAdapter,
+        );
+        final collectionA = await dbA.defaultCollection;
+
+        final configA =
+            ReplicatorConfiguration(
+              target: UrlEndpoint(syncGatewayReplicationUrl),
+              authenticator: janeAuthenticator,
+            )..addCollection(
+              collectionA,
+              CollectionConfiguration(
+                typedConflictResolver: TypedConflictResolver.from(
+                  expectAsync1((conflict) {
+                    expect(conflict.documentId, testDocumentId);
+                    expect(conflict.localDocument, isA<TestTypedDoc>());
+                    expect(conflict.remoteDocument, isA<TestTypedDoc>());
+                    final localDoc = conflict.localDocument! as TestTypedDoc;
+                    final remoteDoc = conflict.remoteDocument! as TestTypedDoc;
+                    expect(localDoc.internal, isTestDocument('DB-A-2'));
+                    expect(remoteDoc.internal, isTestDocument('DB-B-1'));
+                    return conflict.remoteDocument;
+                  }),
+                ),
+              ),
+            );
+        final replicatorA = await Replicator.create(configA);
+        addTearDown(replicatorA.close);
+
+        final dbB = await openTestDatabase(name: 'B');
+        final replicatorB = await dbB.createTestReplicator();
+        addTearDown(replicatorB.close);
+
+        await dbA.writeTestDocument('DB-A-1', type: 'TestTypedDoc');
+        await replicatorA.replicateOneShot();
+        await replicatorB.replicateOneShot();
+        await dbA.writeTestDocument('DB-A-2', type: 'TestTypedDoc');
+        await dbB.writeTestDocument('DB-B-1', type: 'TestTypedDoc');
+        await replicatorB.replicateOneShot();
+        await replicatorA.replicateOneShot();
+
+        expect(await dbA.getTestDocumentOrNull(), isTestDocument('DB-B-1'));
+      },
+    );
 
     apiTest('conflict resolver exception handling', () async {
       Object? uncaughtError;


### PR DESCRIPTION
Add TypedReplicationFilter and TypedConflictResolver support to the modern per-collection replication API. These new experimental fields on CollectionConfiguration are automatically combined with untyped equivalents during replicator creation, enabling typed document handling without changes to replicator implementations.

Includes unit tests for CollectionConfiguration field handling and e2e tests for typed push/pull filters and conflict resolution. Also deprecates typed fields on ReplicatorConfiguration in favor of the modern per-collection API.