### PR TITLE
ci(cbl_e2e_tests): retry Couchbase Server downloads

### DIFF
--- a/packages/cbl_e2e_tests/couchbase-services.sh
+++ b/packages/cbl_e2e_tests/couchbase-services.sh
@@ -290,7 +290,7 @@ function startCouchbaseServerMacOS() {
     if [ ! -d "$cbsAppDir" ]; then
         echo "::group::Install Couchbase Server"
 
-        curl -LO "$cbsUrl"
+        retry 3 10 curl --fail -LO "$cbsUrl"
         local mountOutput
         mountOutput="$(hdiutil attach "$cbsDmg" -nobrowse)"
         local mountPoint
@@ -326,7 +326,7 @@ function startCouchbaseServerWindows() {
 
     echo "::group::Install Couchbase Server"
 
-    curl -LO "$cbsUrl"
+    retry 3 10 curl --fail -LO "$cbsUrl"
     powershell.exe -Command "Start-Process msiexec.exe -Wait -ArgumentList '/i $cbsMsi /qn /norestart'"
     rm "$cbsMsi"
 


### PR DESCRIPTION
Add retry logic to curl downloads of Couchbase Server on macOS and Windows to handle transient network failures. This matches the existing retry pattern used for Sync Gateway downloads and addresses intermittent 'Empty reply from server' errors observed in CI.