### PR TITLE
ci: autopublish packages to pub.dev on tag push

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,28 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - "cbl*-v[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  extract-package:
+    runs-on: ubuntu-latest
+    outputs:
+      package: ${{ steps.package.outputs.package }}
+    steps:
+      - name: Determine package directory
+        id: package
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          package="${tag%-v*}"
+          echo "package=$package" >> "$GITHUB_OUTPUT"
+          echo "Publishing package: $package"
+
+  publish:
+    needs: extract-package
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      working-directory: packages/${{ needs.extract-package.outputs.package }}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically publishes packages to pub.dev when a version tag is pushed. The workflow extracts the package name from the tag (e.g., `cbl-v4.0.0` → `cbl`) and uses the official `dart-lang/setup-dart` reusable publish workflow with OIDC authentication.

Matches tags like `cbl*-v[0-9]+.[0-9]+.[0-9]+*`, covering `cbl`, `cbl_sentry`, and `cbl_generator`.

## Prerequisites

Automated publishing must be enabled on pub.dev for each package.