### PR TITLE
refactor(cbl): use asTypedList(finalizer) in SliceResult

### DIFF
--- a/packages/cbl/lib/src/bindings/fleece.dart
+++ b/packages/cbl/lib/src/bindings/fleece.dart
@@ -137,8 +137,12 @@ extension FLStringResultExt on cblite.FLStringResult {
 }
 
 final class SliceBindings {
+  static final Pointer<NativeFinalizerFunction> sliceResultReleaseByBufPtr =
+      cblitedart.addresses.CBLDart_FLSliceResult_ReleaseByBuf
+          .cast<NativeFinalizerFunction>();
+
   static final _sliceResultFinalizer = NativeFinalizer(
-    cblitedart.addresses.CBLDart_FLSliceResult_ReleaseByBuf.cast(),
+    sliceResultReleaseByBufPtr,
   );
 
   static bool equal(cblite.FLSlice a, cblite.FLSlice b) =>

--- a/packages/cbl/lib/src/bindings/slice.dart
+++ b/packages/cbl/lib/src/bindings/slice.dart
@@ -184,8 +184,6 @@ final class SliceResult extends Slice {
       ? null
       : SliceResult._fromFLSliceResult(slice, retain: retain);
 
-  static final _keepAliveForTypedList = Expando<SliceResult>();
-
   /// Sets the [globalFLSliceResult] to this slice and returns it.
   Pointer<cblite.FLSliceResult> makeGlobalResult() {
     globalFLSliceResult.ref
@@ -205,9 +203,12 @@ final class SliceResult extends Slice {
 
   @override
   Uint8List asTypedList() {
-    final list = super.asTypedList();
-    _keepAliveForTypedList[list] = this;
-    return list;
+    SliceBindings.retainSliceResultByBuf(buf);
+    return buf.cast<Uint8>().asTypedList(
+      size,
+      finalizer: SliceBindings.sliceResultReleaseByBufPtr,
+      token: buf,
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary

- Replace the `Expando`-based mechanism in `SliceResult.asTypedList` with the `finalizer` parameter of `Pointer.asTypedList()`, letting the Dart VM release the native slice when the `Uint8List` is garbage collected.
- Extract the `sliceResultReleaseByBufPtr` as a shared static field in `SliceBindings` for reuse between the `NativeFinalizer` and the typed list finalizer.

Closes #772