### PR TITLE
fix(cbl): add reachability fence for collections in replicator creation

### DIFF
--- a/packages/cbl/lib/src/replication/ffi_replicator.dart
+++ b/packages/cbl/lib/src/replication/ffi_replicator.dart
@@ -155,6 +155,9 @@ final class FfiReplicator
       final pointer = ReplicatorBindings.createReplicator(ffiConfig);
 
       cblReachabilityFence(fleeceContainers);
+      // The collections map is not Finalizable, so the GC can collect it
+      // (and finalize the FfiCollection keys) after its last use above.
+      // Keep the keys alive through the FFI call. See #856.
       cblReachabilityFence(collections.keys);
 
       return FfiReplicator._(


### PR DESCRIPTION
## Summary

Fixes a use-after-free crash (`EXC_BAD_ACCESS` on the `CBL Async Tasks` thread) when creating a replicator.

### Failure mechanism

During replicator creation, native `CBLCollection` pointers are extracted from Dart [`FfiCollection`](https://github.com/cbl-dart/cbl-dart/blob/d795765efb89e80e71ba2f8832e9247c457ebc27/packages/cbl/lib/src/replication/ffi_replicator.dart#L84-L129) objects early on. After this extraction, the Dart objects are no longer referenced. Subsequent allocations before the native [`createReplicator`](https://github.com/cbl-dart/cbl-dart/blob/d795765efb89e80e71ba2f8832e9247c457ebc27/packages/cbl/lib/src/replication/ffi_replicator.dart#L155) call can trigger GC, which finalizes the `FfiCollection` objects and releases the underlying native pointers.

The native `createReplicator` call then receives dangling pointers. Even if the call to retain the collections inside the native code doesn't crash immediately (the freed memory may not yet have been reused), the retained "objects" are garbage. The actual crash occurs later when the C SDK tries to access the collections' internal state.

### Fix

A [`cblReachabilityFence`](https://github.com/cbl-dart/cbl-dart/blob/d795765efb89e80e71ba2f8832e9247c457ebc27/packages/cbl/lib/src/replication/ffi_replicator.dart#L161) keeps the collection objects alive through the FFI call. Once the native call returns, the C SDK holds its own references to the collections, and the Dart-side objects can safely be collected.

Closes #856