### PR TITLE
test(cbl_generator): add test coverage for List<Enum> typed properties

### DIFF
--- a/packages/cbl_generator/test/fixtures/typed_data_list.cbl.type.g.dart
+++ b/packages/cbl_generator/test/fixtures/typed_data_list.cbl.type.g.dart
@@ -416,3 +416,99 @@ class MutableBoolListListDict
     );
   }
 }
+
+mixin _$EnumListDict implements TypedDictionaryObject<MutableEnumListDict> {
+  List<TestEnum> get value;
+}
+
+abstract class _EnumListDictImplBase<I extends Dictionary>
+    with _$EnumListDict
+    implements EnumListDict {
+  _EnumListDictImplBase(this.internal);
+
+  @override
+  final I internal;
+
+  @override
+  MutableEnumListDict toMutable() =>
+      MutableEnumListDict.internal(internal.toMutable());
+
+  @override
+  String toString({String? indent}) => TypedDataHelpers.renderString(
+    indent: indent,
+    className: 'EnumListDict',
+    fields: {'value': value},
+  );
+}
+
+/// DO NOT USE: Internal implementation detail, which might be changed or
+/// removed in the future.
+class ImmutableEnumListDict extends _EnumListDictImplBase {
+  ImmutableEnumListDict.internal(super.internal);
+
+  static const _valueConverter = const TypedListConverter(
+    converter: const ScalarConverterAdapter(
+      const EnumNameConverter(TestEnum.values),
+    ),
+    isNullable: false,
+    isCached: false,
+  );
+
+  @override
+  late final value = TypedDataHelpers.readProperty(
+    internal: internal,
+    name: 'value',
+    key: 'value',
+    converter: _valueConverter,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is EnumListDict &&
+          runtimeType == other.runtimeType &&
+          internal == other.internal;
+
+  @override
+  int get hashCode => internal.hashCode;
+}
+
+/// Mutable version of [EnumListDict].
+class MutableEnumListDict extends _EnumListDictImplBase<MutableDictionary>
+    implements TypedMutableDictionaryObject<EnumListDict, MutableEnumListDict> {
+  /// Creates a new mutable [EnumListDict].
+  MutableEnumListDict(List<TestEnum> value) : super(MutableDictionary()) {
+    this.value = value;
+  }
+
+  MutableEnumListDict.internal(super.internal);
+
+  static const _valueConverter = const TypedListConverter(
+    converter: const ScalarConverterAdapter(
+      const EnumNameConverter(TestEnum.values),
+    ),
+    isNullable: false,
+    isCached: false,
+  );
+
+  late TypedDataList<TestEnum, TestEnum> _value = TypedDataHelpers.readProperty(
+    internal: internal,
+    name: 'value',
+    key: 'value',
+    converter: _valueConverter,
+  );
+
+  @override
+  TypedDataList<TestEnum, TestEnum> get value => _value;
+
+  set value(List<TestEnum> value) {
+    final promoted = _valueConverter.promote(value);
+    _value = promoted;
+    TypedDataHelpers.writeProperty(
+      internal: internal,
+      key: 'value',
+      value: promoted,
+      converter: _valueConverter,
+    );
+  }
+}

--- a/packages/cbl_generator/test/fixtures/typed_data_list.dart
+++ b/packages/cbl_generator/test/fixtures/typed_data_list.dart
@@ -23,3 +23,8 @@ abstract class BoolDictListDict with _$BoolDictListDict {
 abstract class BoolListListDict with _$BoolListListDict {
   factory BoolListListDict(List<List<bool>> value) = MutableBoolListListDict;
 }
+
+@TypedDictionary()
+abstract class EnumListDict with _$EnumListDict {
+  factory EnumListDict(List<TestEnum> value) = MutableEnumListDict;
+}

--- a/packages/cbl_generator/test/functional/typed_data_list_test.dart
+++ b/packages/cbl_generator/test/functional/typed_data_list_test.dart
@@ -1,6 +1,7 @@
 import 'package:cbl/cbl.dart';
 import 'package:test/test.dart';
 
+import '../fixtures/builtin_types.dart';
 import '../fixtures/typed_data_list.dart';
 import '../test_utils.dart';
 
@@ -64,6 +65,21 @@ void main() {
     ]);
     expect((MutableOptionalBoolListDict(null)..value = mutableList).value, [
       false,
+    ]);
+  });
+
+  test('enum list', () {
+    expect(
+      ImmutableEnumListDict.internal(
+        MutableDictionary({
+          'value': ['a'],
+        }),
+      ).value,
+      [TestEnum.a],
+    );
+    expect(MutableEnumListDict([TestEnum.a]).value, [TestEnum.a]);
+    expect((MutableEnumListDict([TestEnum.a])..value = [TestEnum.a]).value, [
+      TestEnum.a,
     ]);
   });
 


### PR DESCRIPTION
## Summary
- Adds test fixture and generated code for `List<TestEnum>` typed dictionary property (`EnumListDict`)
- Adds functional test verifying enum list read/write roundtrip via `ImmutableEnumListDict` and `MutableEnumListDict`
- Prevents regression of #694 where `List<EnumType>` properties could generate `List<dynamic>` instead of properly typed lists