### PR TITLE
test(cbl_e2e_tests): check vectorSearchAvailable instead of vectorSearchEnabled

### DIFF
--- a/packages/cbl_e2e_tests/lib/src/database/collection_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/database/collection_test.dart
@@ -614,7 +614,7 @@ void main() {
 
           expect(ids, documents.map((doc) => doc.id));
         },
-        skip: vectorSearchEnabled
+        skip: vectorSearchAvailable
             ? null
             : 'Vector search not available on this system',
       );

--- a/packages/cbl_e2e_tests/lib/src/query/index_updater_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/query/index_updater_test.dart
@@ -57,7 +57,7 @@ void main() {
           expect(updater, isNull);
         }
       },
-      skip: vectorSearchEnabled
+      skip: vectorSearchAvailable
           ? null
           : 'Vector search not available on this system',
     );
@@ -97,7 +97,7 @@ void main() {
           expect(updater, isNull);
         }
       },
-      skip: vectorSearchEnabled
+      skip: vectorSearchAvailable
           ? null
           : 'Vector search not available on this system',
     );

--- a/packages/cbl_e2e_tests/lib/src/utils/vector_search_utils.dart
+++ b/packages/cbl_e2e_tests/lib/src/utils/vector_search_utils.dart
@@ -1,7 +1,12 @@
 import 'package:cbl/cbl.dart';
 
-/// Whether vector search has been enabled.
+/// Whether vector search is available or has been enabled.
 ///
-/// Use this as a `skip` condition for tests that require vector search.
-bool get vectorSearchEnabled =>
-    Extension.vectorSearchStatus == VectorSearchStatus.enabled;
+/// Use this as a `skip` condition for tests that require vector search. This
+/// checks for both [VectorSearchStatus.available] and
+/// [VectorSearchStatus.enabled] so that it works at test registration time
+/// (before [Extension.enableVectorSearch] is called in `setUpAll`).
+bool get vectorSearchAvailable => switch (Extension.vectorSearchStatus) {
+  VectorSearchStatus.available || VectorSearchStatus.enabled => true,
+  _ => false,
+};


### PR DESCRIPTION
## Summary

- Replace `vectorSearchEnabled` with `vectorSearchAvailable` in test skip conditions to check for both `VectorSearchStatus.available` and `VectorSearchStatus.enabled`, fixing test registration that happens before `enableVectorSearch` is called in `setUpAll`.