### PR TITLE
ci: run CI on docs-only PRs to unblock branch protection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,6 @@ on:
     paths-ignore:
       - docs/**
   pull_request:
-    paths-ignore:
-      - docs/**
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
## Summary

- Removes the `paths-ignore: docs/**` filter from the CI workflow's `pull_request` trigger.
- This fixes docs-only PRs (e.g. dependabot npm updates) getting stuck with CI checks permanently in "Waiting for status to be reported", because the workflow never ran but branch protection required those checks to pass.