### PR TITLE
refactor(cbl): enterprise gating to use capability-based messages

### DIFF
--- a/packages/cbl/lib/src/database/database_configuration.dart
+++ b/packages/cbl/lib/src/database/database_configuration.dart
@@ -77,7 +77,7 @@ final class EncryptionKeyImpl implements EncryptionKey {
 
   // ignore: prefer_constructors_over_static_methods
   static EncryptionKeyImpl key(Uint8List bytes) {
-    useEnterpriseFeature(EnterpriseFeature.databaseEncryption);
+    requireEnterprise('Database encryption');
 
     final keySize = CBLEncryptionAlgorithm.aes256.keySize;
     if (bytes.length != keySize) {
@@ -98,13 +98,13 @@ final class EncryptionKeyImpl implements EncryptionKey {
 
   // ignore: prefer_constructors_over_static_methods
   static EncryptionKeyImpl passwordSync(String password) {
-    useEnterpriseFeature(EnterpriseFeature.databaseEncryption);
+    requireEnterprise('Database encryption');
     final key = DatabaseBindings.encryptionKeyFromPassword(password);
     return EncryptionKeyImpl(key);
   }
 
   static Future<EncryptionKeyImpl> passwordAsync(String password) {
-    useEnterpriseFeature(EnterpriseFeature.databaseEncryption);
+    requireEnterprise('Database encryption');
     return CblWorker.executeCall(
       EncryptionKeyFromPassword(password),
       debugName: 'EncryptionKeyImpl.passwordAsync()',

--- a/packages/cbl/lib/src/database/ffi_database.dart
+++ b/packages/cbl/lib/src/database/ffi_database.dart
@@ -495,7 +495,7 @@ final class FfiCollection
   @override
   void createIndex(String name, covariant IndexImplInterface index) {
     if (index is VectorIndexConfiguration) {
-      useEnterpriseFeature(EnterpriseFeature.vectorIndex);
+      requireEnterprise('Vector indexes');
     }
 
     useSync(() {

--- a/packages/cbl/lib/src/database/proxy_database.dart
+++ b/packages/cbl/lib/src/database/proxy_database.dart
@@ -600,7 +600,7 @@ final class ProxyCollection extends ProxyObject
   @override
   Future<void> createIndex(String name, covariant IndexImplInterface index) {
     if (index is VectorIndexConfiguration) {
-      useEnterpriseFeature(EnterpriseFeature.vectorIndex);
+      requireEnterprise('Vector indexes');
     }
 
     return use(

--- a/packages/cbl/lib/src/query/prediction.dart
+++ b/packages/cbl/lib/src/query/prediction.dart
@@ -122,13 +122,13 @@ abstract final class Prediction {
 final class PredictionImpl implements Prediction {
   @override
   void registerModel(String name, PredictiveModel model) {
-    useEnterpriseFeature(EnterpriseFeature.prediction);
+    requireEnterprise('Prediction');
     _FfiPredictiveModel(name, model);
   }
 
   @override
   void unregisterModel(String name) {
-    useEnterpriseFeature(EnterpriseFeature.prediction);
+    requireEnterprise('Prediction');
     QueryBindings.unregisterPredictiveModel(name);
   }
 }

--- a/packages/cbl/lib/src/replication/configuration.dart
+++ b/packages/cbl/lib/src/replication/configuration.dart
@@ -246,7 +246,7 @@ final class ReplicatorConfiguration {
 
   set acceptOnlySelfSignedServerCertificate(bool value) {
     if (value) {
-      useEnterpriseFeature(EnterpriseFeature.peerToPeerSync);
+      requireEnterprise('Self-signed server certificates');
     }
     _acceptOnlySelfSignedServerCertificate = value;
   }

--- a/packages/cbl/lib/src/replication/ffi_replicator.dart
+++ b/packages/cbl/lib/src/replication/ffi_replicator.dart
@@ -67,7 +67,7 @@ final class FfiReplicator
 
     var target = config.target;
     if (target is DatabaseEndpoint) {
-      useEnterpriseFeature(EnterpriseFeature.localDbReplication);
+      requireEnterprise('Local database replication');
 
       final targetDatabase = target.database;
       if (targetDatabase is ProxyDatabase) {
@@ -83,7 +83,7 @@ final class FfiReplicator
         );
       }
     } else if (target is NativeDatabaseEndpoint) {
-      useEnterpriseFeature(EnterpriseFeature.localDbReplication);
+      requireEnterprise('Local database replication');
     }
 
     final fleeceContainers = <Object>[];
@@ -218,7 +218,7 @@ final class FfiReplicator
 
   @override
   Certificate? get serverCertificate => useSync(() {
-    useEnterpriseFeature(EnterpriseFeature.peerToPeerSync);
+    requireEnterprise('Replicator server certificates');
     return ReplicatorBindings.serverCertificate(
       pointer,
     )?.let((pointer) => FfiCertificate.fromPointer(pointer, adopt: true));

--- a/packages/cbl/lib/src/replication/proxy_replicator.dart
+++ b/packages/cbl/lib/src/replication/proxy_replicator.dart
@@ -51,7 +51,7 @@ final class ProxyReplicator extends ProxyObject
     final configTarget = config.target;
     Endpoint target;
     if (configTarget is DatabaseEndpoint) {
-      useEnterpriseFeature(EnterpriseFeature.localDbReplication);
+      requireEnterprise('Local database replication');
 
       final targetDatabase = configTarget.database;
       if (targetDatabase is ProxyDatabase) {

--- a/packages/cbl/lib/src/replication/tls_identity.dart
+++ b/packages/cbl/lib/src/replication/tls_identity.dart
@@ -609,7 +609,7 @@ final class FfiCertificate implements Certificate, Finalizable {
   }
 
   static FfiCertificate decode(CryptoData data) {
-    useEnterpriseFeature(EnterpriseFeature.peerToPeerSync);
+    requireEnterprise('Certificate decoding');
 
     if (data is PemData && data.blocks.length > 1) {
       throw ArgumentError.value(
@@ -627,7 +627,7 @@ final class FfiCertificate implements Certificate, Finalizable {
   }
 
   static List<FfiCertificate> decodeMultiple(PemData data) {
-    useEnterpriseFeature(EnterpriseFeature.peerToPeerSync);
+    requireEnterprise('Certificate decoding');
     return data.blocks.map(decode).toList();
   }
 
@@ -984,7 +984,7 @@ final class FfiKeyPair implements KeyPair, Finalizable {
   }
 
   static Future<FfiKeyPair> fromExternal(ExternalKeyPairDelegate delegate) {
-    useEnterpriseFeature(EnterpriseFeature.peerToPeerSync);
+    requireEnterprise('TLS key pairs');
 
     final pointer = TlsIdentityBindings.keyPairCreateWithExternalKey(
       keySizeInBits: delegate.keySizeInBits,
@@ -1001,7 +1001,7 @@ final class FfiKeyPair implements KeyPair, Finalizable {
     CryptoData privateKey, {
     String? password,
   }) async {
-    useEnterpriseFeature(EnterpriseFeature.peerToPeerSync);
+    requireEnterprise('TLS key pairs');
 
     final pointer = await Isolate.run(
       () => TlsIdentityBindings.keyPairCreateWithPrivateKey(
@@ -1184,7 +1184,7 @@ final class FfiTlsIdentity implements TlsIdentity, Finalizable {
     required KeyPair keyPair,
     required List<FfiCertificate> certificates,
   }) {
-    useEnterpriseFeature(EnterpriseFeature.peerToPeerSync);
+    requireEnterprise('TLS identities');
 
     final keyPairPointer = (keyPair as FfiKeyPair).pointer;
     final certificateChainPointer = FfiCertificate.combined(
@@ -1207,7 +1207,7 @@ final class FfiTlsIdentity implements TlsIdentity, Finalizable {
     String? label,
     KeyPair? keyPair,
   }) async {
-    useEnterpriseFeature(EnterpriseFeature.peerToPeerSync);
+    requireEnterprise('TLS identities');
 
     if (label != null) {
       _checkPersistedIdentitySupport();
@@ -1248,7 +1248,7 @@ final class FfiTlsIdentity implements TlsIdentity, Finalizable {
   }
 
   static Future<FfiTlsIdentity?> identity(String label) async {
-    useEnterpriseFeature(EnterpriseFeature.peerToPeerSync);
+    requireEnterprise('TLS identities');
     _checkPersistedIdentitySupport();
 
     final pointer = await Isolate.run(
@@ -1264,7 +1264,7 @@ final class FfiTlsIdentity implements TlsIdentity, Finalizable {
   static Future<FfiTlsIdentity> identityWithCertificates(
     List<FfiCertificate> certificates,
   ) async {
-    useEnterpriseFeature(EnterpriseFeature.peerToPeerSync);
+    requireEnterprise('TLS identities');
     _checkPersistedIdentitySupport();
 
     final certificatePointer = FfiCertificate.combined(certificates).pointer;
@@ -1277,7 +1277,7 @@ final class FfiTlsIdentity implements TlsIdentity, Finalizable {
   }
 
   static Future<void> deleteIdentity(String label) async {
-    useEnterpriseFeature(EnterpriseFeature.peerToPeerSync);
+    requireEnterprise('TLS identities');
     _checkPersistedIdentitySupport();
     await Isolate.run(() => TlsIdentityBindings.deleteWithLabel(label));
   }

--- a/packages/cbl/lib/src/replication/url_endpoint_listener.dart
+++ b/packages/cbl/lib/src/replication/url_endpoint_listener.dart
@@ -90,7 +90,7 @@ final class _ListenerPasswordAuthenticator extends FfiListenAuthenticator
   factory _ListenerPasswordAuthenticator(
     ListenerPasswordAuthenticatorFunction handler,
   ) {
-    useEnterpriseFeature(EnterpriseFeature.peerToPeerSync);
+    requireEnterprise('Peer-to-peer sync');
 
     Future<void> trampoline(
       CBLDart_Completer completer,
@@ -181,7 +181,7 @@ final class _ListenerCertificateAuthenticator extends FfiListenAuthenticator
   factory _ListenerCertificateAuthenticator(
     ListenerCertificateAuthenticatorFunction handler,
   ) {
-    useEnterpriseFeature(EnterpriseFeature.peerToPeerSync);
+    requireEnterprise('Peer-to-peer sync');
 
     Future<void> trampoline(
       CBLDart_Completer completer,
@@ -231,7 +231,7 @@ final class _ListenerCertificateAuthenticatorFromRoots
   factory _ListenerCertificateAuthenticatorFromRoots(
     List<Certificate> certificates,
   ) {
-    useEnterpriseFeature(EnterpriseFeature.peerToPeerSync);
+    requireEnterprise('Peer-to-peer sync');
 
     return _ListenerCertificateAuthenticatorFromRoots.fromPointer(
       UrlEndpointListenerBindings.createCertificateAuthenticatorWithRoots(
@@ -460,7 +460,7 @@ final class FfiUrlEndpointListener implements UrlEndpointListener, Finalizable {
   static Future<FfiUrlEndpointListener> create(
     UrlEndpointListenerConfiguration config,
   ) async {
-    useEnterpriseFeature(EnterpriseFeature.peerToPeerSync);
+    requireEnterprise('Peer-to-peer sync');
 
     final pointer = await _create(
       collections: config.collections

--- a/packages/cbl/lib/src/support/edition.dart
+++ b/packages/cbl/lib/src/support/edition.dart
@@ -2,24 +2,6 @@ import '../bindings/cblitedart.dart' as cblitedart;
 
 enum Edition { community, enterprise }
 
-enum EnterpriseFeature {
-  localDbReplication,
-  databaseEncryption,
-  propertyEncryption,
-  prediction,
-  vectorIndex,
-  peerToPeerSync;
-
-  String get description => switch (this) {
-    localDbReplication => 'Local database replication',
-    databaseEncryption => 'Database encryption',
-    propertyEncryption => 'Property encryption',
-    prediction => 'Prediction',
-    vectorIndex => 'Vector index',
-    peerToPeerSync => 'Peer-to-peer sync',
-  };
-}
-
 Edition get activeEdition =>
     _activeEditionOverride ??
     (cblitedart.CBLDart_IsEnterprise()
@@ -32,10 +14,10 @@ set activeEditionOverride(Edition? edition) {
   _activeEditionOverride = edition;
 }
 
-void useEnterpriseFeature(EnterpriseFeature feature) {
+void requireEnterprise(String capability) {
   if (activeEdition != Edition.enterprise) {
     throw StateError(
-      '${feature.description} is only available in the Enterprise Edition.',
+      '$capability is only available in the Enterprise Edition.',
     );
   }
 }

--- a/packages/cbl/test/support/edition_test.dart
+++ b/packages/cbl/test/support/edition_test.dart
@@ -2,33 +2,30 @@ import 'package:cbl/src/support/edition.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('useEnterpriseFeature', () {
+  group('requireEnterprise', () {
     test('returns normally when the enterprise edition is active', () {
       overrideEdition(Edition.enterprise);
 
-      expect(
-        () => useEnterpriseFeature(EnterpriseFeature.databaseEncryption),
-        returnsNormally,
-      );
+      expect(() => requireEnterprise('Database encryption'), returnsNormally);
     });
 
     test('throws when the enterprise edition is not active', () {
       overrideEdition(Edition.community);
 
-      final featureDescription = {
-        EnterpriseFeature.localDbReplication: 'Local database replication',
-        EnterpriseFeature.databaseEncryption: 'Database encryption',
-        EnterpriseFeature.propertyEncryption: 'Property encryption',
-      };
+      const capabilities = [
+        'Local database replication',
+        'Database encryption',
+        'TLS identities',
+      ];
 
-      for (final entry in featureDescription.entries) {
+      for (final capability in capabilities) {
         expect(
-          () => useEnterpriseFeature(entry.key),
+          () => requireEnterprise(capability),
           throwsA(
             isA<StateError>().having(
               (it) => it.message,
               'message',
-              contains(entry.value),
+              contains(capability),
             ),
           ),
         );


### PR DESCRIPTION
## Summary
- remove the `EnterpriseFeature` enum and replace `useEnterpriseFeature(...)` with the central `requireEnterprise(String capability)` guard
- update enterprise-gated call sites to use capability names that match the guarded API surface, including replication TLS, TLS identities, local database replication, prediction, vector indexes, and database encryption
- update the edition guard tests to assert the new message-based behavior

## Testing
- `dart test test/support/edition_test.dart`
- `dart analyze --fatal-infos`