### PR TITLE
ci: run standalone vm-asan e2e tests in the e2e matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -208,7 +208,7 @@ jobs:
 
   test-e2e:
     name: E2E tests
-    timeout-minutes: 15
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -219,6 +219,13 @@ jobs:
           - Android
           - Ubuntu
           - Windows
+        test_platform: [""]
+        include:
+          # `vm-asan` currently requires the raw Dart SDK from the `main`
+          # channel, so we run it as an extra standalone Ubuntu matrix leg.
+          - embedder: standalone
+            os: Ubuntu
+            test_platform: vm-asan
         exclude:
           - embedder: standalone
             os: iOS
@@ -239,6 +246,7 @@ jobs:
     env:
       EMBEDDER: ${{ matrix.embedder }}
       TARGET_OS: ${{ matrix.os }}
+      DART_TEST_PLATFORM: ${{ matrix.test_platform }}
       TEST_PACKAGE: >-
         ${{ fromJSON('{
           "standalone":"cbl_e2e_tests_standalone_dart",
@@ -289,6 +297,13 @@ jobs:
           pub-cache-hash-pattern: pubspec.lock
           cache-provider: ${{ (matrix.os == 'iOS' && matrix.embedder == 'flutter') && 'warp' || 'github' }}
 
+      - name: Setup Dart SDK
+        if: matrix.test_platform == 'vm-asan'
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: main
+          flavor: raw
+
       - name: Enable Flutter native assets
         if: matrix.embedder == 'flutter'
         run: flutter config --enable-native-assets
@@ -318,67 +333,6 @@ jobs:
         run: ./tools/ci-steps.sh startVirtualDevices
 
       - name: Run tests
-        timeout-minutes: 10
-        shell: bash
-        run: ./tools/ci-steps.sh runE2ETests
-
-      - name: Collect test results
-        if: failure()
-        shell: bash
-        run: ./tools/ci-steps.sh collectTestResults
-
-      - name: Upload test results
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: test-results-${{ matrix.os }}-${{ matrix.embedder }}
-          path: test-results
-
-      - name: Upload coverage data
-        # Disabled until we figure out how to get coverage data from flutter tests
-        if: ${{ matrix.embedder != 'flutter' }}
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        shell: bash
-        run: |
-          ./tools/ci-steps.sh uploadCoverageData "e2e.cbl.${{ matrix.embedder }}.${{ matrix.os }}"
-
-  test-e2e-vm-asan:
-    name: E2E tests (vm-asan)
-    timeout-minutes: 25
-    runs-on: runs-on=${{ github.run_id }}/runner=ubuntu22-4cpu
-    env:
-      EMBEDDER: standalone
-      TARGET_OS: Ubuntu
-      TEST_PACKAGE: cbl_e2e_tests_standalone_dart
-      DART_TEST_PLATFORM: vm-asan
-    steps:
-      - uses: runs-on/action@v2
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Flutter
-        uses: ./.github/actions/setup-flutter
-        with:
-          channel: ${{ env.flutter-channel }}
-          cache: true
-          pub-cache-hash-pattern: pubspec.lock
-
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@v1
-        with:
-          sdk: main
-          flavor: raw
-
-      - name: Get dependencies
-        shell: bash
-        run: ./tools/ci-steps.sh prepareStandaloneSanitizerE2ETests
-
-      - name: Start Couchbase services
-        shell: bash
-        run: ./tools/ci-steps.sh startCouchbaseServices
-
-      - name: Run tests
         timeout-minutes: 20
         shell: bash
         run: ./tools/ci-steps.sh runE2ETests
@@ -392,5 +346,14 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: test-results-Ubuntu-standalone-vm-asan
+          name: test-results-${{ matrix.os }}-${{ matrix.embedder }}${{ matrix.test_platform && format('-{0}', matrix.test_platform) || '' }}
           path: test-results
+
+      - name: Upload coverage data
+        # Disabled until we figure out how to get coverage data from flutter tests
+        if: ${{ matrix.embedder != 'flutter' && matrix.test_platform == '' }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        shell: bash
+        run: |
+          ./tools/ci-steps.sh uploadCoverageData "e2e.cbl.${{ matrix.embedder }}.${{ matrix.os }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -356,6 +356,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup Flutter
+        uses: ./.github/actions/setup-flutter
+        with:
+          channel: ${{ env.flutter-channel }}
+          cache: true
+          pub-cache-hash-pattern: pubspec.lock
+
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -385,6 +385,34 @@ jobs:
           cd packages/cbl_e2e_tests_standalone_dart
           export ENABLE_TIME_BOMB=true
           ulimit -c unlimited
+
+          # `dart test -p vm-asan` compiles test suites to native shared
+          # libraries, but that execution path does not currently wire native
+          # assets into the generated process. Build hooks still materialize the
+          # native libraries into `.dart_tool/lib`, so preload them to satisfy
+          # `@ffi.DefaultAsset`'s fallback to process symbol lookup.
+          dart test --help >/dev/null
+
+          native_lib_dir="$PWD/.dart_tool/lib"
+          export LD_LIBRARY_PATH="$native_lib_dir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+          libcblite="$(find "$native_lib_dir" -maxdepth 1 -type f -name 'libcblite.so*' | head -n 1)"
+          libcblitedart="$(find "$native_lib_dir" -maxdepth 1 -type f -name 'libcblitedart.so*' | head -n 1)"
+          extra_libs="$(find "$native_lib_dir" -maxdepth 1 -type f \( -name '*.so' -o -name '*.so.*' \) \
+            ! -name 'libcblite.so*' \
+            ! -name 'libcblitedart.so*' | sort | paste -sd ':' -)"
+
+          preload_libs=()
+          [ -n "$libcblite" ] && preload_libs+=("$libcblite")
+          [ -n "$libcblitedart" ] && preload_libs+=("$libcblitedart")
+          [ -n "$extra_libs" ] && preload_libs+=("$extra_libs")
+
+          if [ "${#preload_libs[@]}" -eq 0 ]; then
+            echo "No native libraries found to preload in $native_lib_dir"
+            exit 1
+          fi
+
+          export LD_PRELOAD="$(IFS=:; echo "${preload_libs[*]}")"
           dart test -p vm-asan -r expanded -j 1
 
       - name: Collect test results

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -351,10 +351,18 @@ jobs:
       EMBEDDER: standalone
       TARGET_OS: Ubuntu
       TEST_PACKAGE: cbl_e2e_tests_standalone_dart
+      DART_TEST_PLATFORM: vm-asan
     steps:
       - uses: runs-on/action@v2
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      - name: Setup Flutter
+        uses: ./.github/actions/setup-flutter
+        with:
+          channel: ${{ env.flutter-channel }}
+          cache: true
+          pub-cache-hash-pattern: pubspec.lock
 
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1
@@ -364,15 +372,7 @@ jobs:
 
       - name: Get dependencies
         shell: bash
-        run: |
-          python3 - <<'PY'
-          from pathlib import Path
-          pubspec = Path('pubspec.yaml')
-          pubspec.write_text(
-              pubspec.read_text().replace('  - packages/cbl_e2e_tests_flutter\n', ''),
-          )
-          PY
-          dart pub upgrade test test_api test_core
+        run: ./tools/ci-steps.sh prepareStandaloneSanitizerE2ETests
 
       - name: Start Couchbase services
         shell: bash
@@ -381,39 +381,7 @@ jobs:
       - name: Run tests
         timeout-minutes: 20
         shell: bash
-        run: |
-          cd packages/cbl_e2e_tests_standalone_dart
-          export ENABLE_TIME_BOMB=true
-          ulimit -c unlimited
-
-          # `dart test -p vm-asan` compiles test suites to native shared
-          # libraries, but that execution path does not currently wire native
-          # assets into the generated process. Build hooks still materialize the
-          # native libraries into `.dart_tool/lib`, so preload them to satisfy
-          # `@ffi.DefaultAsset`'s fallback to process symbol lookup.
-          dart test --help >/dev/null
-
-          native_lib_dir="$PWD/.dart_tool/lib"
-          export LD_LIBRARY_PATH="$native_lib_dir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-
-          libcblite="$(find "$native_lib_dir" -maxdepth 1 -type f -name 'libcblite.so*' | head -n 1)"
-          libcblitedart="$(find "$native_lib_dir" -maxdepth 1 -type f -name 'libcblitedart.so*' | head -n 1)"
-          extra_libs="$(find "$native_lib_dir" -maxdepth 1 -type f \( -name '*.so' -o -name '*.so.*' \) \
-            ! -name 'libcblite.so*' \
-            ! -name 'libcblitedart.so*' | sort | paste -sd ':' -)"
-
-          preload_libs=()
-          [ -n "$libcblite" ] && preload_libs+=("$libcblite")
-          [ -n "$libcblitedart" ] && preload_libs+=("$libcblitedart")
-          [ -n "$extra_libs" ] && preload_libs+=("$extra_libs")
-
-          if [ "${#preload_libs[@]}" -eq 0 ]; then
-            echo "No native libraries found to preload in $native_lib_dir"
-            exit 1
-          fi
-
-          export LD_PRELOAD="$(IFS=:; echo "${preload_libs[*]}")"
-          dart test -p vm-asan -r expanded -j 1
+        run: ./tools/ci-steps.sh runE2ETests
 
       - name: Collect test results
         if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -356,13 +356,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup Flutter
-        uses: ./.github/actions/setup-flutter
-        with:
-          channel: ${{ env.flutter-channel }}
-          cache: true
-          pub-cache-hash-pattern: pubspec.lock
-
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1
         with:
@@ -370,7 +363,16 @@ jobs:
           flavor: raw
 
       - name: Get dependencies
-        run: dart pub get
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          pubspec = Path('pubspec.yaml')
+          pubspec.write_text(
+              pubspec.read_text().replace('  - packages/cbl_e2e_tests_flutter\n', ''),
+          )
+          PY
+          dart pub upgrade test test_api test_core
 
       - name: Start Couchbase services
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -342,3 +342,50 @@ jobs:
         shell: bash
         run: |
           ./tools/ci-steps.sh uploadCoverageData "e2e.cbl.${{ matrix.embedder }}.${{ matrix.os }}"
+
+  test-e2e-vm-asan:
+    name: E2E tests (vm-asan)
+    timeout-minutes: 25
+    runs-on: runs-on=${{ github.run_id }}/runner=ubuntu22-4cpu
+    env:
+      EMBEDDER: standalone
+      TARGET_OS: Ubuntu
+      TEST_PACKAGE: cbl_e2e_tests_standalone_dart
+    steps:
+      - uses: runs-on/action@v2
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: main
+          flavor: raw
+
+      - name: Get dependencies
+        run: dart pub get
+
+      - name: Start Couchbase services
+        shell: bash
+        run: ./tools/ci-steps.sh startCouchbaseServices
+
+      - name: Run tests
+        timeout-minutes: 20
+        shell: bash
+        run: |
+          cd packages/cbl_e2e_tests_standalone_dart
+          export ENABLE_TIME_BOMB=true
+          ulimit -c unlimited
+          dart test -p vm-asan -r expanded -j 1
+
+      - name: Collect test results
+        if: failure()
+        shell: bash
+        run: ./tools/ci-steps.sh collectTestResults
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-Ubuntu-standalone-vm-asan
+          path: test-results

--- a/packages/cbl/lib/src/typed_data/registry.dart
+++ b/packages/cbl/lib/src/typed_data/registry.dart
@@ -185,17 +185,14 @@ final class TypedDataRegistry implements TypedDataAdapter {
         TypedDataErrorCode.typeMatchingConflict,
       );
     } else {
-      assert(() {
-        if (matchingMetadata.isNotEmpty) {
-          throw TypedDataException(
-            'Expected to find a document that matches no type matcher, '
-            'but found a document that matches the type matchers of the '
-            'following types: $matchingMetadata',
-            TypedDataErrorCode.typeMatchingConflict,
-          );
-        }
-        return true;
-      }());
+      if (matchingMetadata.isNotEmpty) {
+        throw TypedDataException(
+          'Expected to find a document that matches no type matcher, '
+          'but found a document that matches the type matchers of the '
+          'following types: $matchingMetadata',
+          TypedDataErrorCode.typeMatchingConflict,
+        );
+      }
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -550,10 +550,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: f2c65e21139ce2c3dad46922be8272bb5963516045659e71bb16e151c93b580e
+      sha256: "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.22"
+    version: "2.2.23"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -840,29 +840,29 @@ packages:
     source: hosted
     version: "1.2.2"
   test:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,10 @@ dev_dependencies:
 
 dependency_overrides:
   meta: ^1.18.0
+  # `dart test -p vm-asan` is first supported by package:test 1.31.0.
+  # Keep the entire workspace on that test runner so the standalone sanitizer
+  # CI leg can resolve compatible dependencies without carving Flutter out of
+  # the workspace.
   test: 1.31.0
   test_api: 0.7.11
   test_core: 0.6.17

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,9 @@ dev_dependencies:
 
 dependency_overrides:
   meta: ^1.18.0
+  test: 1.31.0
+  test_api: 0.7.11
+  test_core: 0.6.17
 
 melos:
   repository: https://github.com/cbl-dart/cbl-dart

--- a/tools/ci-steps.sh
+++ b/tools/ci-steps.sh
@@ -136,6 +136,49 @@ function runUnitTests() {
     esac
 }
 
+function prepareStandaloneSanitizerE2ETests() {
+    requireEnvVar TEST_PACKAGE
+    requireEnvVar DART_TEST_PLATFORM
+
+    cd "$workspaceDir"
+    dart pub get
+}
+
+function _prepareStandaloneSanitizerNativeAssets() {
+    requireEnvVar DART_TEST_PLATFORM
+
+    # `dart test -p vm-asan` compiles test suites to native shared libraries,
+    # but that execution path does not currently wire native assets into the
+    # generated process. Build hooks still materialize the native libraries
+    # into `.dart_tool/lib`, so preload them to satisfy `@ffi.DefaultAsset`'s
+    # fallback to process symbol lookup.
+    dart test --help >/dev/null
+
+    local nativeLibDir="$PWD/.dart_tool/lib"
+    export LD_LIBRARY_PATH="$nativeLibDir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+    local libcblite
+    libcblite="$(find "$nativeLibDir" -maxdepth 1 -type f -name 'libcblite.so*' | head -n 1)"
+    local libcblitedart
+    libcblitedart="$(find "$nativeLibDir" -maxdepth 1 -type f -name 'libcblitedart.so*' | head -n 1)"
+    local extraLibs
+    extraLibs="$(find "$nativeLibDir" -maxdepth 1 -type f \( -name '*.so' -o -name '*.so.*' \) \
+        ! -name 'libcblite.so*' \
+        ! -name 'libcblitedart.so*' | sort | paste -sd ':' -)"
+
+    local preloadLibs=()
+    [ -n "$libcblite" ] && preloadLibs+=("$libcblite")
+    [ -n "$libcblitedart" ] && preloadLibs+=("$libcblitedart")
+    [ -n "$extraLibs" ] && preloadLibs+=("$extraLibs")
+
+    if [ "${#preloadLibs[@]}" -eq 0 ]; then
+        echo "No native libraries found to preload in $nativeLibDir"
+        exit 1
+    fi
+
+    export LD_PRELOAD="$(IFS=:; echo "${preloadLibs[*]}")"
+}
+
 function runE2ETests() {
     requireEnvVar EMBEDDER
     requireEnvVar TARGET_OS
@@ -148,7 +191,14 @@ function runE2ETests() {
         cd "$testPackageDir"
 
         export ENABLE_TIME_BOMB=true
-        testCommand="dart test --coverage coverage/dart -r expanded -j 1"
+        testCommand="dart test -r expanded -j 1"
+
+        if [[ -n "${DART_TEST_PLATFORM:-}" ]]; then
+            testCommand="$testCommand -p $DART_TEST_PLATFORM"
+            _prepareStandaloneSanitizerNativeAssets
+        else
+            testCommand="$testCommand --coverage coverage/dart"
+        fi
 
         case "$targetOs" in
         macOS)

--- a/tools/ci-steps.sh
+++ b/tools/ci-steps.sh
@@ -136,14 +136,6 @@ function runUnitTests() {
     esac
 }
 
-function prepareStandaloneSanitizerE2ETests() {
-    requireEnvVar TEST_PACKAGE
-    requireEnvVar DART_TEST_PLATFORM
-
-    cd "$workspaceDir"
-    dart pub get
-}
-
 function _prepareStandaloneSanitizerNativeAssets() {
     requireEnvVar DART_TEST_PLATFORM
 


### PR DESCRIPTION
## Summary
- run standalone `vm-asan` e2e tests as an extra Ubuntu leg in the e2e matrix
- force the workspace onto `test 1.31.0`, `test_api 0.7.11`, and `test_core 0.6.17` so `vm-asan` is supported without carving Flutter out of the workspace
- preload native libraries for the sanitizer runner because `dart test -p vm-asan` does not currently wire native assets into the generated process
