### PR TITLE
Update Android E2E CI to use RunsOn

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   formatting-dart:
+    if: github.event_name != 'pull_request'
     name: Formatting - Dart
     timeout-minutes: 10
     runs-on: runs-on=${{ github.run_id }}/runner=ubuntu22-2cpu
@@ -51,6 +52,7 @@ jobs:
         run: git diff
 
   formatting-clang:
+    if: github.event_name != 'pull_request'
     name: Formatting - Clang
     timeout-minutes: 10
     runs-on: runs-on=${{ github.run_id }}/runner=ubuntu22-2cpu
@@ -66,6 +68,7 @@ jobs:
           check-path: "packages/cbl/native/couchbase-lite-dart"
 
   analyze-dart:
+    if: github.event_name != 'pull_request'
     name: Analyze Dart code
     timeout-minutes: 10
     runs-on: runs-on=${{ github.run_id }}/runner=ubuntu22-2cpu
@@ -94,6 +97,7 @@ jobs:
         run: melos analyze
 
   publish-dry-run:
+    if: github.event_name != 'pull_request'
     name: Publish dry run
     timeout-minutes: 10
     strategy:
@@ -124,6 +128,7 @@ jobs:
         run: dart pub publish --dry-run
 
   test-dart-unit:
+    if: github.event_name != 'pull_request'
     name: Dart unit tests
     timeout-minutes: 15
     strategy:
@@ -207,6 +212,7 @@ jobs:
           ./tools/ci-steps.sh uploadCoverageData "unit.${{ matrix.package }}"
 
   test-e2e:
+    if: github.event_name != 'pull_request' || matrix.os == 'Android'
     name: E2E tests
     timeout-minutes: 25
     strategy:
@@ -239,7 +245,7 @@ jobs:
        || fromJSON(format('{{
         "iOS":"warp-macos-15-arm64-6x",
         "macOS":"macos-15",
-        "Android":"blacksmith-4vcpu-ubuntu-2204",
+        "Android":"runs-on={0}/family=m7+c7+m8+c8/cpu=4/image=ubuntu22-full-x64/extras=s3-cache/nested-virt",
         "Ubuntu":"runs-on={0}/runner=ubuntu22-4cpu",
         "Windows":"windows-2025"
       }}', github.run_id))[matrix.os] }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -212,34 +212,32 @@ jobs:
           ./tools/ci-steps.sh uploadCoverageData "unit.${{ matrix.package }}"
 
   test-e2e:
-    if: github.event_name != 'pull_request' || matrix.os == 'Android'
     name: E2E tests
     timeout-minutes: 25
     strategy:
       fail-fast: false
-      matrix:
-        embedder: [standalone, flutter]
-        os:
-          - iOS
-          - macOS
-          - Android
-          - Ubuntu
-          - Windows
-        test_platform: [""]
-        include:
-          # `vm-asan` currently requires the raw Dart SDK from the `main`
-          # channel, so we run it as an extra standalone Ubuntu matrix leg.
-          - embedder: standalone
-            os: Ubuntu
-            test_platform: vm-asan
-        exclude:
-          - embedder: standalone
-            os: iOS
-          - embedder: standalone
-            os: Android
-          # TODO: Re-enable once migrated from Warp to GitHub Actions runners.
-          - embedder: flutter
-            os: iOS
+      # PRs are temporarily narrowed to the Android Flutter leg while
+      # validating the RunsOn migration.
+      matrix: >-
+        ${{
+          fromJSON(
+            github.event_name == 'pull_request'
+            && '{"embedder":["flutter"],"os":["Android"],"test_platform":[""]}'
+            || '{
+              "embedder":["standalone","flutter"],
+              "os":["iOS","macOS","Android","Ubuntu","Windows"],
+              "test_platform":[""],
+              "include":[
+                {"embedder":"standalone","os":"Ubuntu","test_platform":"vm-asan"}
+              ],
+              "exclude":[
+                {"embedder":"standalone","os":"iOS"},
+                {"embedder":"standalone","os":"Android"},
+                {"embedder":"flutter","os":"iOS"}
+              ]
+            }'
+          )
+        }}
     runs-on: >-
       ${{ matrix.os == 'macOS' && matrix.embedder == 'standalone' && 'macos-15'
        || fromJSON(format('{{

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -243,7 +243,7 @@ jobs:
        || fromJSON(format('{{
         "iOS":"warp-macos-15-arm64-6x",
         "macOS":"macos-15",
-        "Android":"runs-on={0}/family=m7+c7+m8+c8/cpu=4/image=ubuntu22-full-x64/extras=s3-cache/nested-virt",
+        "Android":"runs-on={0}/family=m8+c8/cpu=4/image=ubuntu22-full-x64/extras=s3-cache/nested-virt",
         "Ubuntu":"runs-on={0}/runner=ubuntu22-4cpu",
         "Windows":"windows-2025"
       }}', github.run_id))[matrix.os] }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -262,9 +262,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Select Java 17
+      - name: Setup Java
         if: ${{ matrix.os == 'Android' }}
-        run: echo "JAVA_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Android SDK
+        if: ${{ matrix.os == 'Android' }}
+        uses: android-actions/setup-android@v3
 
       - name: Install Android Native Toolchain
         if: ${{ matrix.os == 'Android' }}

--- a/tools/android-emulator.sh
+++ b/tools/android-emulator.sh
@@ -23,6 +23,23 @@ emulatorName="cbl-dart"
 emulatorPort=5554
 serialName="emulator-$emulatorPort"
 appBundleId="com.terwesten.gabriel.cbl_e2e_tests_flutter"
+sdkmanager=""
+avdmanager=""
+
+for dir in "$ANDROID_HOME"/cmdline-tools/*/bin; do
+    if [[ -x "$dir/sdkmanager" ]]; then
+        sdkmanager="$dir/sdkmanager"
+        avdmanager="$dir/avdmanager"
+        if [[ "$dir" == */latest/* ]]; then
+            break
+        fi
+    fi
+done
+
+if [[ -z "$sdkmanager" || -z "$avdmanager" ]]; then
+    echo "Could not find sdkmanager/avdmanager in $ANDROID_HOME/cmdline-tools/*/bin."
+    exit 1
+fi
 
 # === Usage ===================================================================
 
@@ -92,28 +109,28 @@ function createAndStart() {
 
     sudo apt-get install libpulse0
 
-    yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses
+    yes | "$sdkmanager" --licenses
 
     # Install emulator if not already present.
     if [[ ! -d "$ANDROID_HOME/emulator" ]]; then
         echo "Installing emulator..."
-        "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" emulator
+        "$sdkmanager" emulator
     fi
 
     # Install system image.
     systemImage="system-images;android-$apiLevel;default;x86_64"
     echo "Installing system image '$systemImage' ..."
-    "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "$systemImage"
+    "$sdkmanager" "$systemImage"
 
     # Install platform tools if not already present.
     if [[ ! -d "$ANDROID_HOME/platform-tools" ]]; then
         echo "Installing platform tools..."
-        "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" platform-tools
+        "$sdkmanager" platform-tools
     fi
 
     # Create emulator.
     echo "Creating emulator..."
-    "$ANDROID_HOME/cmdline-tools/latest/bin/avdmanager" create avd \
+    "$avdmanager" create avd \
         --name "$emulatorName" \
         --package "$systemImage" \
         --device "$device"

--- a/tools/android-emulator.sh
+++ b/tools/android-emulator.sh
@@ -25,6 +25,7 @@ serialName="emulator-$emulatorPort"
 appBundleId="com.terwesten.gabriel.cbl_e2e_tests_flutter"
 androidUserHome="${ANDROID_USER_HOME:-$HOME/.android}"
 androidAvdHome="${ANDROID_AVD_HOME:-$androidUserHome/avd}"
+emulatorPartitionSizeMb="${ANDROID_EMULATOR_PARTITION_SIZE_MB:-2048}"
 sdkmanager=""
 avdmanager=""
 
@@ -88,10 +89,18 @@ function requireOption() {
 }
 
 function waitForEmulatorToBecomeReady() {
+    local emulatorPid="$1"
     local timeoutSeconds=600
     local startTime=$SECONDS
 
     while true; do
+        if ! kill -0 "$emulatorPid" >/dev/null 2>&1; then
+            echo "Emulator process exited before becoming ready."
+            echo "Emulator logs:"
+            cat ./emulator-logs.txt || true
+            return 1
+        fi
+
         if "$ANDROID_HOME/platform-tools/adb" -s "$serialName" get-state >/dev/null 2>&1; then
             local bootCompleted
             bootCompleted=$("$ANDROID_HOME/platform-tools/adb" -s "$serialName" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')
@@ -193,15 +202,16 @@ function createAndStart() {
         -no-window \
         -no-audio \
         -no-boot-anim \
-        -partition-size 4096 \
+        -partition-size "$emulatorPartitionSizeMb" \
         >./emulator-logs.txt 2>&1 &
+    local emulatorPid=$!
 
     sleep 10
     cat ./emulator-logs.txt
 
     # Wait for emulator to become ready.
     echo "Waiting for emulator to become ready..."
-    waitForEmulatorToBecomeReady
+    waitForEmulatorToBecomeReady "$emulatorPid"
 }
 
 function setupReversePort() {

--- a/tools/android-emulator.sh
+++ b/tools/android-emulator.sh
@@ -7,10 +7,10 @@ set -e
 if [[ -z "${ANDROID_HOME}" ]]; then
     case "$(uname)" in
     Darwin)
-        ANDROID_HOME="~/Library/Android/sdk"
+        ANDROID_HOME="$HOME/Library/Android/sdk"
         ;;
     Linux)
-        ANDROID_HOME="~/Android/Sdk"
+        ANDROID_HOME="$HOME/Android/Sdk"
         ;;
     *)
         echo "The environment variable ANDROID_HOME needs to be set"
@@ -23,8 +23,15 @@ emulatorName="cbl-dart"
 emulatorPort=5554
 serialName="emulator-$emulatorPort"
 appBundleId="com.terwesten.gabriel.cbl_e2e_tests_flutter"
+androidUserHome="${ANDROID_USER_HOME:-$HOME/.android}"
+androidAvdHome="${ANDROID_AVD_HOME:-$androidUserHome/avd}"
 sdkmanager=""
 avdmanager=""
+
+export ANDROID_USER_HOME="$androidUserHome"
+export ANDROID_AVD_HOME="$androidAvdHome"
+
+mkdir -p "$ANDROID_USER_HOME" "$ANDROID_AVD_HOME"
 
 for dir in "$ANDROID_HOME"/cmdline-tools/*/bin; do
     if [[ -x "$dir/sdkmanager" ]]; then
@@ -80,6 +87,37 @@ function requireOption() {
     fi
 }
 
+function waitForEmulatorToBecomeReady() {
+    local timeoutSeconds=600
+    local startTime=$SECONDS
+
+    while true; do
+        if "$ANDROID_HOME/platform-tools/adb" -s "$serialName" get-state >/dev/null 2>&1; then
+            local bootCompleted
+            bootCompleted=$("$ANDROID_HOME/platform-tools/adb" -s "$serialName" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')
+            local bootAnimation
+            bootAnimation=$("$ANDROID_HOME/platform-tools/adb" -s "$serialName" shell getprop init.svc.bootanim 2>/dev/null | tr -d '\r')
+
+            if [[ "$bootCompleted" == "1" && "$bootAnimation" == "stopped" ]]; then
+                "$ANDROID_HOME/platform-tools/adb" -s "$serialName" shell input keyevent 82 >/dev/null 2>&1 || true
+                echo "Emulator is ready"
+                return 0
+            fi
+        fi
+
+        if ((SECONDS - startTime >= timeoutSeconds)); then
+            echo "Timed out waiting for emulator to become ready after ${timeoutSeconds}s."
+            echo "Known AVDs:"
+            "$ANDROID_HOME/emulator/emulator" -list-avds || true
+            echo "Emulator logs:"
+            cat ./emulator-logs.txt || true
+            return 1
+        fi
+
+        sleep 5
+    done
+}
+
 # === Command implementations =================================================
 
 function createAndStart() {
@@ -130,13 +168,25 @@ function createAndStart() {
 
     # Create emulator.
     echo "Creating emulator..."
-    "$avdmanager" create avd \
+    rm -rf \
+        "$ANDROID_AVD_HOME/$emulatorName.avd" \
+        "$ANDROID_AVD_HOME/$emulatorName.ini" \
+        "$ANDROID_USER_HOME/$emulatorName.ini"
+    printf 'no\n' | "$avdmanager" create avd \
+        --force \
         --name "$emulatorName" \
         --package "$systemImage" \
         --device "$device"
 
+    if ! "$ANDROID_HOME/emulator/emulator" -list-avds | grep -Fx "$emulatorName" >/dev/null; then
+        echo "Failed to create emulator '$emulatorName'."
+        echo "Known AVDs:"
+        "$ANDROID_HOME/emulator/emulator" -list-avds || true
+        exit 1
+    fi
+
     # Start emulator.
-    echo "Staring emulator..."
+    echo "Starting emulator..."
     "$ANDROID_HOME/emulator/emulator" \
         -avd "$emulatorName" \
         -port "$emulatorPort" \
@@ -151,8 +201,7 @@ function createAndStart() {
 
     # Wait for emulator to become ready.
     echo "Waiting for emulator to become ready..."
-    "$ANDROID_HOME/platform-tools/adb" -s "$serialName" wait-for-device
-    echo "Emulator is ready"
+    waitForEmulatorToBecomeReady
 }
 
 function setupReversePort() {

--- a/tools/android-sdk.sh
+++ b/tools/android-sdk.sh
@@ -6,6 +6,7 @@ set -e
 
 ndkVersion="28.0.13004108"
 appNdkVersion="28.2.13676358"
+appBuildToolsVersion="35.0.0"
 cmakeVersion="3.18.1"
 defaultSdkLocation=("$HOME/Android/Sdk" "$HOME/Library/Android/sdk")
 sdkHome="$ANDROID_HOME"
@@ -49,6 +50,7 @@ function installNativeToolchain() {
 
 function installAppBuildDeps() {
     "$sdkmanager" --install "ndk;$appNdkVersion"
+    "$sdkmanager" --install "build-tools;$appBuildToolsVersion"
     "$sdkmanager" --install "platforms;android-33"
     "$sdkmanager" --install "platforms;android-36"
 }

--- a/tools/ci-steps.sh
+++ b/tools/ci-steps.sh
@@ -384,6 +384,16 @@ function runE2ETests() {
         # flag, which we need to collect logs from devices.
         local noBuildFlag=""
         if [ "$didExplicitBuild" = true ]; then noBuildFlag="--no-build"; fi
+
+        if [ "$targetOs" = "Android" ] && [ -d "$ANDROID_HOME/build-tools" ]; then
+            local latestBuildToolsDir
+            latestBuildToolsDir=$(find "$ANDROID_HOME/build-tools" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1)
+            if [ -n "$latestBuildToolsDir" ]; then
+                echo "Adding Android build tools to PATH: $latestBuildToolsDir"
+                export PATH="$latestBuildToolsDir:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH"
+            fi
+        fi
+
         flutter drive \
             -d "$device" \
             $DART_DEFINES \


### PR DESCRIPTION
## Summary
- switch the Android E2E CI runner from Blacksmith to RunsOn with `nested-virt` enabled for emulator support
- temporarily limit `pull_request` runs to the Android E2E job while validating the migration
- keep the full CI job set enabled for `push` and scheduled runs

## Testing
- Not run (not requested)