### PR TITLE
ci: allow Codecov uploads from forked pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -201,6 +201,7 @@ jobs:
 
       - name: Upload coverage data
         env:
+          CODECOV_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.head.label || github.head_ref || github.ref_name }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         shell: bash
         run: |
@@ -353,6 +354,7 @@ jobs:
         # Disabled until we figure out how to get coverage data from flutter tests
         if: ${{ matrix.embedder != 'flutter' && matrix.test_platform == '' }}
         env:
+          CODECOV_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.head.label || github.head_ref || github.ref_name }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         shell: bash
         run: |

--- a/tools/ci-steps.sh
+++ b/tools/ci-steps.sh
@@ -709,13 +709,20 @@ function uploadCoverageData() {
     esac
 
     # Upload coverage data
-    ./codecov \
-        --verbose \
-        upload-process \
-        --fail-on-error \
-        --flag "$flags" \
-        --file "$testPackageDir/coverage/lcov.info" \
+    local codecovArgs=(
+        --verbose
+        upload-process
+        --fail-on-error
+        --flag "$flags"
+        --file "$testPackageDir/coverage/lcov.info"
         --commit-sha "$GITHUB_SHA"
+    )
+
+    if [[ -n "${CODECOV_BRANCH:-}" ]]; then
+        codecovArgs+=(--branch "$CODECOV_BRANCH")
+    fi
+
+    ./codecov "${codecovArgs[@]}"
 }
 
 "$@"


### PR DESCRIPTION
## Summary
- Pass a Codecov-friendly branch name for PRs, including forked PRs, so coverage uploads do not fail on protected branches.
- Forward the computed branch to the Codecov CLI in the shared upload helper.
- Keep the existing token-based path for regular branch and scheduled uploads.

## Testing
- `bash -n tools/ci-steps.sh`
- `actionlint -ignore 'SC2086' .github/workflows/ci.yaml`
- `git diff --check`