### PR TITLE
test(cbl_generator): isolate generator tests with explicit package config

### DIFF
--- a/packages/cbl_generator/test/generator/typed_database_generator_test.dart
+++ b/packages/cbl_generator/test/generator/typed_database_generator_test.dart
@@ -38,6 +38,7 @@ class $A {
 '''),
       },
       readerWriter: readerWriter,
+      packageConfig: (await PackageAssetReader.currentIsolate()).packageConfig,
       outputs: {
         _genPartId: _typedDatabaseGeneratorContent(r'''
 class A extends $A {
@@ -110,6 +111,7 @@ Future<void> _expectBadSource(String source, [Object? messageMatcher]) async {
     {_testLibId: _testLibContent(source)},
     onLog: captureError,
     readerWriter: readerWriter,
+    packageConfig: (await PackageAssetReader.currentIsolate()).packageConfig,
   );
 
   await expectLater(errorMessage, effectiveMatcher ?? isNotNull);

--- a/packages/cbl_generator/test/generator/typed_dictionary_generator_test.dart
+++ b/packages/cbl_generator/test/generator/typed_dictionary_generator_test.dart
@@ -79,6 +79,7 @@ abstract class A with _$A {
 '''),
       },
       readerWriter: readerWriter,
+      packageConfig: (await PackageAssetReader.currentIsolate()).packageConfig,
       outputs: {
         _genPartId: _typedDictionaryGeneratorContent(r'''
 mixin _$A implements TypedDictionaryObject<MutableA> {}
@@ -147,6 +148,7 @@ abstract class A with _$A {
 '''),
       },
       readerWriter: readerWriter,
+      packageConfig: (await PackageAssetReader.currentIsolate()).packageConfig,
       outputs: {
         _genPartId: _typedDictionaryGeneratorContent(r'''
 mixin _$A implements TypedDictionaryObject<MutableA> {
@@ -380,6 +382,7 @@ Future<void> _expectBadSource(String source, [Object? messageMatcher]) async {
     {_testLibId: _testLibContent(source)},
     onLog: captureError,
     readerWriter: readerWriter,
+    packageConfig: (await PackageAssetReader.currentIsolate()).packageConfig,
   );
 
   await expectLater(errorMessage, effectiveMatcher ?? isNotNull);


### PR DESCRIPTION
## Summary
- Pass the current isolate package config into `testBuilder` calls in the typed database and typed dictionary generator tests.
- This avoids the shared `ResolversImpl` path in `build_test` and gives each synthetic build its own resolver state, reducing CI flakiness from analyzer cache reuse.

## Testing
- `dart run daco format packages/cbl_generator/test/generator/typed_dictionary_generator_test.dart packages/cbl_generator/test/generator/typed_database_generator_test.dart`
- `cd packages/cbl_generator && dart test --coverage coverage/dart -r expanded -j 1 --timeout 30s`
- `dart analyze --fatal-infos packages/cbl_generator`