### PR TITLE
ci: Aggregate Codecov coverage by component and flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -223,7 +223,7 @@ jobs:
 
   test-e2e:
     name: E2E tests
-    timeout-minutes: 35
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -469,7 +469,6 @@ jobs:
         with:
           directory: coverage-artifacts/unit.runtime.vm.platform.ubuntu
           flags: unit,runtime.vm,platform.ubuntu
-          name: unit.runtime.vm.platform.ubuntu
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -481,7 +480,6 @@ jobs:
         with:
           directory: coverage-artifacts/unit.runtime.vm.platform.macos
           flags: unit,runtime.vm,platform.macos
-          name: unit.runtime.vm.platform.macos
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -493,7 +491,6 @@ jobs:
         with:
           directory: coverage-artifacts/unit.runtime.vm.platform.windows
           flags: unit,runtime.vm,platform.windows
-          name: unit.runtime.vm.platform.windows
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -505,7 +502,6 @@ jobs:
         with:
           directory: coverage-artifacts/e2e.runtime.vm.platform.ubuntu
           flags: e2e,runtime.vm,platform.ubuntu
-          name: e2e.runtime.vm.platform.ubuntu
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -517,7 +513,6 @@ jobs:
         with:
           directory: coverage-artifacts/e2e.runtime.vm.platform.macos
           flags: e2e,runtime.vm,platform.macos
-          name: e2e.runtime.vm.platform.macos
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -529,7 +524,6 @@ jobs:
         with:
           directory: coverage-artifacts/e2e.runtime.vm.platform.windows
           flags: e2e,runtime.vm,platform.windows
-          name: e2e.runtime.vm.platform.windows
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -541,7 +535,6 @@ jobs:
         with:
           directory: coverage-artifacts/e2e.runtime.vm.sanitizer.asan.platform.ubuntu
           flags: e2e,runtime.vm,sanitizer.asan,platform.ubuntu
-          name: e2e.runtime.vm.sanitizer.asan.platform.ubuntu
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -376,24 +376,19 @@ jobs:
 
       - name: Collect coverage data
         # Disabled until we figure out how to get coverage data from flutter tests
-        if: ${{ always() && steps.run-tests.outcome != 'skipped' && matrix.embedder != 'flutter' }}
+        if: ${{ always() && steps.run-tests.outcome != 'skipped' && matrix.embedder != 'flutter' && matrix.test_platform == '' }}
         shell: bash
         env:
           ALLOW_MISSING_COVERAGE: ${{ steps.run-tests.outcome == 'success' && 'false' || 'true' }}
         run: |
-          coverageGroup="e2e.runtime.vm.platform.$CODECOV_PLATFORM"
-          if [ "${DART_TEST_PLATFORM:-}" = "vm-asan" ]; then
-            coverageGroup="e2e.runtime.vm.sanitizer.asan.platform.$CODECOV_PLATFORM"
-          fi
-
-          ./tools/ci-steps.sh collectCoverageData "e2e.cbl.${{ matrix.embedder }}.${{ matrix.os }}${{ matrix.test_platform && format('.{0}', matrix.test_platform) || '' }}" "$coverageGroup"
+          ./tools/ci-steps.sh collectCoverageData "e2e.cbl.${{ matrix.embedder }}.${{ matrix.os }}" "e2e.runtime.vm.platform.$CODECOV_PLATFORM"
 
       - name: Upload coverage artifact
         # Disabled until we figure out how to get coverage data from flutter tests
-        if: ${{ always() && hashFiles('coverage-artifacts/**') != '' && matrix.embedder != 'flutter' }}
+        if: ${{ always() && hashFiles('coverage-artifacts/**') != '' && matrix.embedder != 'flutter' && matrix.test_platform == '' }}
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-e2e-cbl-${{ matrix.embedder }}-${{ matrix.os }}${{ matrix.test_platform && format('-{0}', matrix.test_platform) || '' }}
+          name: coverage-e2e-cbl-${{ matrix.embedder }}-${{ matrix.os }}
           path: coverage-artifacts
 
   upload-coverage:
@@ -524,17 +519,6 @@ jobs:
         with:
           directory: coverage-artifacts/e2e.runtime.vm.platform.windows
           flags: e2e,runtime.vm,platform.windows
-          override_branch: ${{ env.CODECOV_BRANCH }}
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
-
-      - name: Upload Ubuntu VM ASAN E2E coverage
-        if: ${{ hashFiles('coverage-artifacts/e2e.runtime.vm.sanitizer.asan.platform.ubuntu/**') != '' }}
-        uses: codecov/codecov-action@v5
-        with:
-          directory: coverage-artifacts/e2e.runtime.vm.sanitizer.asan.platform.ubuntu
-          flags: e2e,runtime.vm,sanitizer.asan,platform.ubuntu
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -196,15 +196,20 @@ jobs:
         run: ./tools/ci-steps.sh checkBuildRunnerOutput
 
       - name: Run tests
+        id: run-tests
         shell: bash
         run: ./tools/ci-steps.sh runUnitTests
 
       - name: Collect coverage data
+        if: ${{ always() && steps.run-tests.outcome != 'skipped' }}
         shell: bash
+        env:
+          ALLOW_MISSING_COVERAGE: ${{ steps.run-tests.outcome == 'success' && 'false' || 'true' }}
         run: |
           ./tools/ci-steps.sh collectCoverageData "unit.${{ matrix.package }}.${{ matrix.os }}" "unit.${{ matrix.package }}"
 
       - name: Upload coverage artifact
+        if: ${{ always() && hashFiles('coverage-artifacts/**') != '' }}
         uses: actions/upload-artifact@v7
         with:
           name: coverage-unit-${{ matrix.package }}-${{ matrix.os }}
@@ -337,6 +342,7 @@ jobs:
         run: ./tools/ci-steps.sh startVirtualDevices
 
       - name: Run tests
+        id: run-tests
         timeout-minutes: 20
         shell: bash
         run: ./tools/ci-steps.sh runE2ETests
@@ -356,14 +362,16 @@ jobs:
 
       - name: Collect coverage data
         # Disabled until we figure out how to get coverage data from flutter tests
-        if: ${{ matrix.embedder != 'flutter' && matrix.test_platform == '' }}
+        if: ${{ always() && steps.run-tests.outcome != 'skipped' && matrix.embedder != 'flutter' && matrix.test_platform == '' }}
         shell: bash
+        env:
+          ALLOW_MISSING_COVERAGE: ${{ steps.run-tests.outcome == 'success' && 'false' || 'true' }}
         run: |
           ./tools/ci-steps.sh collectCoverageData "e2e.cbl.${{ matrix.embedder }}.${{ matrix.os }}" "e2e.cbl.${{ matrix.embedder }}.${{ matrix.os }}"
 
       - name: Upload coverage artifact
         # Disabled until we figure out how to get coverage data from flutter tests
-        if: ${{ matrix.embedder != 'flutter' && matrix.test_platform == '' }}
+        if: ${{ always() && hashFiles('coverage-artifacts/**') != '' && matrix.embedder != 'flutter' && matrix.test_platform == '' }}
         uses: actions/upload-artifact@v7
         with:
           name: coverage-e2e-cbl-${{ matrix.embedder }}-${{ matrix.os }}
@@ -379,7 +387,15 @@ jobs:
       - publish-dry-run
       - test-dart-unit
       - test-e2e
-    if: ${{ always() && !cancelled() && needs.test-dart-unit.result == 'success' && needs.test-e2e.result == 'success' }}
+    if: >-
+      ${{
+        always() &&
+        !cancelled() &&
+        (
+          github.event_name == 'pull_request' ||
+          (needs.test-dart-unit.result == 'success' && needs.test-e2e.result == 'success')
+        )
+      }}
     runs-on: runs-on=${{ github.run_id }}/runner=ubuntu22-2cpu
     env:
       CODECOV_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.head.label || github.head_ref || github.ref_name }}
@@ -390,12 +406,24 @@ jobs:
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@v7
+        continue-on-error: true
         with:
           pattern: coverage-*
           path: coverage-artifacts
           merge-multiple: true
 
+      - name: Detect downloaded coverage
+        id: coverage
+        shell: bash
+        run: |
+          if [ -d coverage-artifacts ] && find coverage-artifacts -type f -name '*.lcov.info' | grep -q .; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload cbl unit coverage
+        if: ${{ hashFiles('coverage-artifacts/unit.cbl/**') != '' }}
         uses: codecov/codecov-action@v5
         with:
           directory: coverage-artifacts/unit.cbl
@@ -407,6 +435,7 @@ jobs:
           verbose: true
 
       - name: Upload cbl_sentry unit coverage
+        if: ${{ hashFiles('coverage-artifacts/unit.cbl_sentry/**') != '' }}
         uses: codecov/codecov-action@v5
         with:
           directory: coverage-artifacts/unit.cbl_sentry
@@ -418,6 +447,7 @@ jobs:
           verbose: true
 
       - name: Upload cbl_generator unit coverage
+        if: ${{ hashFiles('coverage-artifacts/unit.cbl_generator/**') != '' }}
         uses: codecov/codecov-action@v5
         with:
           directory: coverage-artifacts/unit.cbl_generator
@@ -429,6 +459,7 @@ jobs:
           verbose: true
 
       - name: Upload macOS standalone E2E coverage
+        if: ${{ hashFiles('coverage-artifacts/e2e.cbl.standalone.macOS/**') != '' }}
         uses: codecov/codecov-action@v5
         with:
           directory: coverage-artifacts/e2e.cbl.standalone.macOS
@@ -440,6 +471,7 @@ jobs:
           verbose: true
 
       - name: Upload Ubuntu standalone E2E coverage
+        if: ${{ hashFiles('coverage-artifacts/e2e.cbl.standalone.Ubuntu/**') != '' }}
         uses: codecov/codecov-action@v5
         with:
           directory: coverage-artifacts/e2e.cbl.standalone.Ubuntu
@@ -451,6 +483,7 @@ jobs:
           verbose: true
 
       - name: Upload Windows standalone E2E coverage
+        if: ${{ hashFiles('coverage-artifacts/e2e.cbl.standalone.Windows/**') != '' }}
         uses: codecov/codecov-action@v5
         with:
           directory: coverage-artifacts/e2e.cbl.standalone.Windows
@@ -462,6 +495,7 @@ jobs:
           verbose: true
 
       - name: Send Codecov notifications
+        if: ${{ steps.coverage.outputs.found == 'true' }}
         uses: codecov/codecov-action@v5
         with:
           run_command: send-notifications

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -199,13 +199,16 @@ jobs:
         shell: bash
         run: ./tools/ci-steps.sh runUnitTests
 
-      - name: Upload coverage data
-        env:
-          CODECOV_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.head.label || github.head_ref || github.ref_name }}
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Collect coverage data
         shell: bash
         run: |
-          ./tools/ci-steps.sh uploadCoverageData "unit.${{ matrix.package }}"
+          ./tools/ci-steps.sh collectCoverageData "unit.${{ matrix.package }}.${{ matrix.os }}" "unit.${{ matrix.package }}"
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-unit-${{ matrix.package }}-${{ matrix.os }}
+          path: coverage-artifacts
 
   test-e2e:
     name: E2E tests
@@ -261,7 +264,7 @@ jobs:
 
       - name: Select Java 17
         if: ${{ matrix.os == 'Android' }}
-        run: echo "JAVA_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
+        run: echo "JAVA_HOME=$JAVA_HOME_17_X64" >> "$GITHUB_ENV"
 
       - name: Install Android Native Toolchain
         if: ${{ matrix.os == 'Android' }}
@@ -350,12 +353,118 @@ jobs:
           name: test-results-${{ matrix.os }}-${{ matrix.embedder }}${{ matrix.test_platform && format('-{0}', matrix.test_platform) || '' }}
           path: test-results
 
-      - name: Upload coverage data
+      - name: Collect coverage data
         # Disabled until we figure out how to get coverage data from flutter tests
         if: ${{ matrix.embedder != 'flutter' && matrix.test_platform == '' }}
-        env:
-          CODECOV_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.head.label || github.head_ref || github.ref_name }}
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         shell: bash
         run: |
-          ./tools/ci-steps.sh uploadCoverageData "e2e.cbl.${{ matrix.embedder }}.${{ matrix.os }}"
+          ./tools/ci-steps.sh collectCoverageData "e2e.cbl.${{ matrix.embedder }}.${{ matrix.os }}" "e2e.cbl.${{ matrix.embedder }}.${{ matrix.os }}"
+
+      - name: Upload coverage artifact
+        # Disabled until we figure out how to get coverage data from flutter tests
+        if: ${{ matrix.embedder != 'flutter' && matrix.test_platform == '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-e2e-cbl-${{ matrix.embedder }}-${{ matrix.os }}
+          path: coverage-artifacts
+
+  upload-coverage:
+    name: Upload coverage
+    timeout-minutes: 10
+    needs:
+      - formatting-dart
+      - formatting-clang
+      - analyze-dart
+      - publish-dry-run
+      - test-dart-unit
+      - test-e2e
+    if: ${{ always() && !cancelled() && needs.test-dart-unit.result == 'success' && needs.test-e2e.result == 'success' }}
+    runs-on: runs-on=${{ github.run_id }}/runner=ubuntu22-2cpu
+    env:
+      CODECOV_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.head.label || github.head_ref || github.ref_name }}
+    steps:
+      - uses: runs-on/action@v2
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: coverage-*
+          path: coverage-artifacts
+          merge-multiple: true
+
+      - name: Upload cbl unit coverage
+        uses: codecov/codecov-action@v5
+        with:
+          directory: coverage-artifacts/unit.cbl
+          flags: unit.cbl
+          name: unit.cbl
+          override_branch: ${{ env.CODECOV_BRANCH }}
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+      - name: Upload cbl_sentry unit coverage
+        uses: codecov/codecov-action@v5
+        with:
+          directory: coverage-artifacts/unit.cbl_sentry
+          flags: unit.cbl_sentry
+          name: unit.cbl_sentry
+          override_branch: ${{ env.CODECOV_BRANCH }}
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+      - name: Upload cbl_generator unit coverage
+        uses: codecov/codecov-action@v5
+        with:
+          directory: coverage-artifacts/unit.cbl_generator
+          flags: unit.cbl_generator
+          name: unit.cbl_generator
+          override_branch: ${{ env.CODECOV_BRANCH }}
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+      - name: Upload macOS standalone E2E coverage
+        uses: codecov/codecov-action@v5
+        with:
+          directory: coverage-artifacts/e2e.cbl.standalone.macOS
+          flags: e2e.cbl.standalone.macOS
+          name: e2e.cbl.standalone.macOS
+          override_branch: ${{ env.CODECOV_BRANCH }}
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+      - name: Upload Ubuntu standalone E2E coverage
+        uses: codecov/codecov-action@v5
+        with:
+          directory: coverage-artifacts/e2e.cbl.standalone.Ubuntu
+          flags: e2e.cbl.standalone.Ubuntu
+          name: e2e.cbl.standalone.Ubuntu
+          override_branch: ${{ env.CODECOV_BRANCH }}
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+      - name: Upload Windows standalone E2E coverage
+        uses: codecov/codecov-action@v5
+        with:
+          directory: coverage-artifacts/e2e.cbl.standalone.Windows
+          flags: e2e.cbl.standalone.Windows
+          name: e2e.cbl.standalone.Windows
+          override_branch: ${{ env.CODECOV_BRANCH }}
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+      - name: Send Codecov notifications
+        uses: codecov/codecov-action@v5
+        with:
+          run_command: send-notifications
+          override_branch: ${{ env.CODECOV_BRANCH }}
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,6 +140,12 @@ jobs:
             embedder: standalone
             os: Windows
     env:
+      CODECOV_PLATFORM: >-
+        ${{ fromJSON('{
+          "Ubuntu":"ubuntu",
+          "macOS":"macos",
+          "Windows":"windows"
+        }')[matrix.os] }}
       EMBEDDER: ${{ matrix.embedder }}
       TARGET_OS: ${{ matrix.os }}
       TEST_PACKAGE: ${{ matrix.package }}
@@ -206,7 +212,7 @@ jobs:
         env:
           ALLOW_MISSING_COVERAGE: ${{ steps.run-tests.outcome == 'success' && 'false' || 'true' }}
         run: |
-          ./tools/ci-steps.sh collectCoverageData "unit.${{ matrix.package }}.${{ matrix.os }}" "unit.${{ matrix.package }}"
+          ./tools/ci-steps.sh collectCoverageData "unit.${{ matrix.package }}.${{ matrix.os }}" "unit.runtime.vm.platform.$CODECOV_PLATFORM"
 
       - name: Upload coverage artifact
         if: ${{ always() && hashFiles('coverage-artifacts/**') != '' }}
@@ -253,6 +259,14 @@ jobs:
         "Windows":"windows-2025"
       }}', github.run_id))[matrix.os] }}
     env:
+      CODECOV_PLATFORM: >-
+        ${{ fromJSON('{
+          "iOS":"ios",
+          "macOS":"macos",
+          "Android":"android",
+          "Ubuntu":"ubuntu",
+          "Windows":"windows"
+        }')[matrix.os] }}
       EMBEDDER: ${{ matrix.embedder }}
       TARGET_OS: ${{ matrix.os }}
       DART_TEST_PLATFORM: ${{ matrix.test_platform }}
@@ -362,19 +376,24 @@ jobs:
 
       - name: Collect coverage data
         # Disabled until we figure out how to get coverage data from flutter tests
-        if: ${{ always() && steps.run-tests.outcome != 'skipped' && matrix.embedder != 'flutter' && matrix.test_platform == '' }}
+        if: ${{ always() && steps.run-tests.outcome != 'skipped' && matrix.embedder != 'flutter' }}
         shell: bash
         env:
           ALLOW_MISSING_COVERAGE: ${{ steps.run-tests.outcome == 'success' && 'false' || 'true' }}
         run: |
-          ./tools/ci-steps.sh collectCoverageData "e2e.cbl.${{ matrix.embedder }}.${{ matrix.os }}" "e2e.cbl.${{ matrix.embedder }}.${{ matrix.os }}"
+          coverageGroup="e2e.runtime.vm.platform.$CODECOV_PLATFORM"
+          if [ "${DART_TEST_PLATFORM:-}" = "vm-asan" ]; then
+            coverageGroup="e2e.runtime.vm.sanitizer.asan.platform.$CODECOV_PLATFORM"
+          fi
+
+          ./tools/ci-steps.sh collectCoverageData "e2e.cbl.${{ matrix.embedder }}.${{ matrix.os }}${{ matrix.test_platform && format('.{0}', matrix.test_platform) || '' }}" "$coverageGroup"
 
       - name: Upload coverage artifact
         # Disabled until we figure out how to get coverage data from flutter tests
-        if: ${{ always() && hashFiles('coverage-artifacts/**') != '' && matrix.embedder != 'flutter' && matrix.test_platform == '' }}
+        if: ${{ always() && hashFiles('coverage-artifacts/**') != '' && matrix.embedder != 'flutter' }}
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-e2e-cbl-${{ matrix.embedder }}-${{ matrix.os }}
+          name: coverage-e2e-cbl-${{ matrix.embedder }}-${{ matrix.os }}${{ matrix.test_platform && format('-{0}', matrix.test_platform) || '' }}
           path: coverage-artifacts
 
   upload-coverage:
@@ -444,73 +463,85 @@ jobs:
             rm -f "$reportsFile"
           done
 
-      - name: Upload cbl unit coverage
-        if: ${{ hashFiles('coverage-artifacts/unit.cbl/**') != '' }}
+      - name: Upload Ubuntu VM unit coverage
+        if: ${{ hashFiles('coverage-artifacts/unit.runtime.vm.platform.ubuntu/**') != '' }}
         uses: codecov/codecov-action@v5
         with:
-          directory: coverage-artifacts/unit.cbl
-          flags: unit.cbl
-          name: unit.cbl
+          directory: coverage-artifacts/unit.runtime.vm.platform.ubuntu
+          flags: unit,runtime.vm,platform.ubuntu
+          name: unit.runtime.vm.platform.ubuntu
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
-      - name: Upload cbl_sentry unit coverage
-        if: ${{ hashFiles('coverage-artifacts/unit.cbl_sentry/**') != '' }}
+      - name: Upload macOS VM unit coverage
+        if: ${{ hashFiles('coverage-artifacts/unit.runtime.vm.platform.macos/**') != '' }}
         uses: codecov/codecov-action@v5
         with:
-          directory: coverage-artifacts/unit.cbl_sentry
-          flags: unit.cbl_sentry
-          name: unit.cbl_sentry
+          directory: coverage-artifacts/unit.runtime.vm.platform.macos
+          flags: unit,runtime.vm,platform.macos
+          name: unit.runtime.vm.platform.macos
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
-      - name: Upload cbl_generator unit coverage
-        if: ${{ hashFiles('coverage-artifacts/unit.cbl_generator/**') != '' }}
+      - name: Upload Windows VM unit coverage
+        if: ${{ hashFiles('coverage-artifacts/unit.runtime.vm.platform.windows/**') != '' }}
         uses: codecov/codecov-action@v5
         with:
-          directory: coverage-artifacts/unit.cbl_generator
-          flags: unit.cbl_generator
-          name: unit.cbl_generator
+          directory: coverage-artifacts/unit.runtime.vm.platform.windows
+          flags: unit,runtime.vm,platform.windows
+          name: unit.runtime.vm.platform.windows
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
-      - name: Upload macOS standalone E2E coverage
-        if: ${{ hashFiles('coverage-artifacts/e2e.cbl.standalone.macOS/**') != '' }}
+      - name: Upload Ubuntu VM E2E coverage
+        if: ${{ hashFiles('coverage-artifacts/e2e.runtime.vm.platform.ubuntu/**') != '' }}
         uses: codecov/codecov-action@v5
         with:
-          directory: coverage-artifacts/e2e.cbl.standalone.macOS
-          flags: e2e.cbl.standalone.macOS
-          name: e2e.cbl.standalone.macOS
+          directory: coverage-artifacts/e2e.runtime.vm.platform.ubuntu
+          flags: e2e,runtime.vm,platform.ubuntu
+          name: e2e.runtime.vm.platform.ubuntu
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
-      - name: Upload Ubuntu standalone E2E coverage
-        if: ${{ hashFiles('coverage-artifacts/e2e.cbl.standalone.Ubuntu/**') != '' }}
+      - name: Upload macOS VM E2E coverage
+        if: ${{ hashFiles('coverage-artifacts/e2e.runtime.vm.platform.macos/**') != '' }}
         uses: codecov/codecov-action@v5
         with:
-          directory: coverage-artifacts/e2e.cbl.standalone.Ubuntu
-          flags: e2e.cbl.standalone.Ubuntu
-          name: e2e.cbl.standalone.Ubuntu
+          directory: coverage-artifacts/e2e.runtime.vm.platform.macos
+          flags: e2e,runtime.vm,platform.macos
+          name: e2e.runtime.vm.platform.macos
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
-      - name: Upload Windows standalone E2E coverage
-        if: ${{ hashFiles('coverage-artifacts/e2e.cbl.standalone.Windows/**') != '' }}
+      - name: Upload Windows VM E2E coverage
+        if: ${{ hashFiles('coverage-artifacts/e2e.runtime.vm.platform.windows/**') != '' }}
         uses: codecov/codecov-action@v5
         with:
-          directory: coverage-artifacts/e2e.cbl.standalone.Windows
-          flags: e2e.cbl.standalone.Windows
-          name: e2e.cbl.standalone.Windows
+          directory: coverage-artifacts/e2e.runtime.vm.platform.windows
+          flags: e2e,runtime.vm,platform.windows
+          name: e2e.runtime.vm.platform.windows
+          override_branch: ${{ env.CODECOV_BRANCH }}
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+      - name: Upload Ubuntu VM ASAN E2E coverage
+        if: ${{ hashFiles('coverage-artifacts/e2e.runtime.vm.sanitizer.asan.platform.ubuntu/**') != '' }}
+        uses: codecov/codecov-action@v5
+        with:
+          directory: coverage-artifacts/e2e.runtime.vm.sanitizer.asan.platform.ubuntu
+          flags: e2e,runtime.vm,sanitizer.asan,platform.ubuntu
+          name: e2e.runtime.vm.sanitizer.asan.platform.ubuntu
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -212,7 +212,7 @@ jobs:
 
   test-e2e:
     name: E2E tests
-    timeout-minutes: 25
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
@@ -343,11 +343,12 @@ jobs:
 
       - name: Collect test results
         if: failure()
+        timeout-minutes: 8
         shell: bash
         run: ./tools/ci-steps.sh collectTestResults
 
       - name: Upload test results
-        if: failure()
+        if: ${{ failure() && hashFiles('test-results/**') != '' }}
         uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.embedder }}${{ matrix.test_platform && format('-{0}', matrix.test_platform) || '' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -422,6 +422,28 @@ jobs:
             echo "found=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Prepare Codecov reports
+        if: ${{ steps.coverage.outputs.found == 'true' }}
+        shell: bash
+        run: |
+          for flagDir in coverage-artifacts/*; do
+            [ -d "$flagDir" ] || continue
+
+            reportsFile="$(mktemp)"
+            find "$flagDir" -maxdepth 1 -type f -name '*.lcov.info' | sort > "$reportsFile"
+            [ -s "$reportsFile" ] || {
+              rm -f "$reportsFile"
+              continue
+            }
+
+            reportCount="$(wc -l < "$reportsFile" | tr -d ' ')"
+            printf 'Preparing %s from %s report(s)\n' "$flagDir/lcov.info" "$reportCount"
+            while IFS= read -r report; do
+              cat "$report"
+            done < "$reportsFile" > "$flagDir/lcov.info"
+            rm -f "$reportsFile"
+          done
+
       - name: Upload cbl unit coverage
         if: ${{ hashFiles('coverage-artifacts/unit.cbl/**') != '' }}
         uses: codecov/codecov-action@v5

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,13 @@ codecov:
     # only after every report has been uploaded.
     manual_trigger: true
 
+flag_management:
+  default_rules:
+    # Missing flags can be carried forward from the base commit. This keeps
+    # partial PR uploads useful when a matrix leg fails before producing
+    # coverage, while the failed CI leg still reports the actual failure.
+    carryforward: true
+
 component_management:
   individual_components:
     - component_id: cbl

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,9 @@ ignore:
 
 codecov:
   notify:
-    after_n_builds: 2
+    # Coverage uploads are aggregated in CI and notifications are triggered
+    # only after every report has been uploaded.
+    manual_trigger: true
 
 coverage:
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,21 @@ codecov:
     # only after every report has been uploaded.
     manual_trigger: true
 
+component_management:
+  individual_components:
+    - component_id: cbl
+      name: cbl
+      paths:
+        - packages/cbl/lib/**
+    - component_id: cbl_sentry
+      name: cbl_sentry
+      paths:
+        - packages/cbl_sentry/lib/**
+    - component_id: cbl_generator
+      name: cbl_generator
+      paths:
+        - packages/cbl_generator/lib/**
+
 coverage:
   status:
     project:

--- a/tools/android-emulator.sh
+++ b/tools/android-emulator.sh
@@ -32,6 +32,9 @@ COMMANDS
     createAndStart -a API-LEVEL -d DEVICE
         creates and starts an emulator
 
+    diagnostics -o OUTPUT-DIRECTORY
+        collects emulator diagnostics
+
     setupReversePort PORT
         proxies a port from the emulator to the host
 
@@ -65,6 +68,66 @@ function requireOption() {
 
 # === Command implementations =================================================
 
+function adbForEmulator() {
+    "$ANDROID_HOME/platform-tools/adb" -s "$serialName" "$@"
+}
+
+function waitForBootProperty() {
+    local property="$1"
+    local expected="$2"
+    local timeoutSeconds="$3"
+    local elapsed=0
+
+    echo "Waiting for $property to become $expected..."
+
+    while [[ $elapsed -lt $timeoutSeconds ]]; do
+        local value
+        value="$(adbForEmulator shell getprop "$property" 2>/dev/null | tr -d '\r')"
+
+        if [[ "$value" == "$expected" ]]; then
+            echo "$property is $expected"
+            return 0
+        fi
+
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+
+    echo "Timed out waiting for $property to become $expected"
+    return 1
+}
+
+function waitForPackageManager() {
+    local timeoutSeconds="$1"
+    local elapsed=0
+
+    echo "Waiting for Android package manager..."
+
+    while [[ $elapsed -lt $timeoutSeconds ]]; do
+        if adbForEmulator shell cmd package list packages >/dev/null 2>&1; then
+            echo "Android package manager is ready"
+            return 0
+        fi
+
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+
+    echo "Timed out waiting for Android package manager"
+    return 1
+}
+
+function waitForEmulatorReady() {
+    echo "Waiting for emulator to become ready..."
+    adbForEmulator wait-for-device
+    waitForBootProperty sys.boot_completed 1 180
+    waitForBootProperty dev.bootcomplete 1 180
+    waitForPackageManager 180
+    adbForEmulator shell input keyevent 82 >/dev/null 2>&1 || true
+    "$ANDROID_HOME/platform-tools/adb" devices -l
+    echo "Emulator is ready"
+}
+
 function createAndStart() {
     local apiLevel=""
     local device=""
@@ -90,7 +153,7 @@ function createAndStart() {
     sudo udevadm control --reload-rules
     sudo udevadm trigger --name-match=kvm
 
-    sudo apt-get install libpulse0
+    sudo apt-get install -y --no-install-recommends libpulse0
 
     yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses
 
@@ -126,16 +189,14 @@ function createAndStart() {
         -no-window \
         -no-audio \
         -no-boot-anim \
+        -no-metrics \
         -partition-size 4096 \
         >./emulator-logs.txt 2>&1 &
 
     sleep 10
     cat ./emulator-logs.txt
 
-    # Wait for emulator to become ready.
-    echo "Waiting for emulator to become ready..."
-    "$ANDROID_HOME/platform-tools/adb" -s "$serialName" wait-for-device
-    echo "Emulator is ready"
+    waitForEmulatorReady
 }
 
 function setupReversePort() {
@@ -144,7 +205,36 @@ function setupReversePort() {
     requireOption -p PORT "$port"
 
     echo "Setting up reverse socket connect for port $port"
-    "$ANDROID_HOME/platform-tools/adb" -s "$serialName" reverse "tcp:$1" "tcp:$1"
+    adbForEmulator reverse "tcp:$1" "tcp:$1"
+}
+
+function diagnostics() {
+    local outputDirectory=""
+
+    while getopts "o:" optName; do
+        case "$optName" in
+        o)
+            outputDirectory="$OPTARG"
+            ;;
+        ?)
+            usageFailure
+            ;;
+        esac
+    done
+
+    requireOption -o OUTPUT-DIRECTORY "$outputDirectory"
+
+    mkdir -p "$outputDirectory"
+
+    "$ANDROID_HOME/platform-tools/adb" devices -l >"$outputDirectory/adb-devices.txt" 2>&1 || true
+    adbForEmulator shell getprop >"$outputDirectory/getprop.txt" 2>&1 || true
+    adbForEmulator shell dumpsys activity processes >"$outputDirectory/dumpsys-activity-processes.txt" 2>&1 || true
+    adbForEmulator shell dumpsys package "$appBundleId" >"$outputDirectory/dumpsys-package.txt" 2>&1 || true
+    adbForEmulator logcat -d -v threadtime >"$outputDirectory/logcat.txt" 2>&1 || true
+
+    if [[ -f ./emulator-logs.txt ]]; then
+        cp -a ./emulator-logs.txt "$outputDirectory/"
+    fi
 }
 
 function bugreport() {
@@ -167,8 +257,7 @@ function bugreport() {
 
     mkdir -p "$outputDirectory"
 
-    "$ANDROID_HOME/platform-tools/adb" \
-        -s "$serialName" \
+    adbForEmulator \
         bugreport \
         "$outputDirectory"
 
@@ -176,8 +265,8 @@ function bugreport() {
 }
 
 function copyAppData() {
-    "$ANDROID_HOME/platform-tools/adb" shell "run-as $appBundleId cp -r /data/data/$appBundleId /mnt/sdcard"
-    "$ANDROID_HOME/platform-tools/adb" pull "/mnt/sdcard/$appBundleId" "appData"
+    adbForEmulator shell "run-as $appBundleId cp -r /data/data/$appBundleId /mnt/sdcard"
+    adbForEmulator pull "/mnt/sdcard/$appBundleId" "appData"
 }
 
 # === Parse command ===========================================================
@@ -188,6 +277,7 @@ fi
 
 commands=(
     createAndStart
+    diagnostics
     setupReversePort
     bugreport
     copyAppData

--- a/tools/ci-steps.sh
+++ b/tools/ci-steps.sh
@@ -196,13 +196,11 @@ function runE2ETests() {
         cd "$testPackageDir"
 
         export ENABLE_TIME_BOMB=true
-        testCommand="dart test -r expanded -j 1"
+        testCommand="dart test -r expanded -j 1 --coverage coverage/dart"
 
         if [[ -n "${DART_TEST_PLATFORM:-}" ]]; then
             testCommand="$testCommand -p $DART_TEST_PLATFORM"
             _prepareStandaloneSanitizerNativeAssets
-        else
-            testCommand="$testCommand --coverage coverage/dart"
         fi
 
         case "$targetOs" in
@@ -786,10 +784,10 @@ function _hasCoverageInput() {
 # Collects coverage data in a repository-root artifact directory.
 #
 # The first parameter is the unique upload name.
-# The second parameter is a comma separated list of Codecov flags.
+# The second parameter is the coverage artifact group.
 function collectCoverageData() {
     local uploadName="$1"
-    local flags="$2"
+    local artifactGroup="$2"
     local artifactDir="${COVERAGE_ARTIFACTS_DIR:-coverage-artifacts}"
     local allowMissing="${ALLOW_MISSING_COVERAGE:-false}"
 
@@ -818,8 +816,8 @@ function collectCoverageData() {
         return 1
     fi
 
-    mkdir -p "$artifactDir/$flags"
-    cp "$lcovFile" "$artifactDir/$flags/$uploadName.lcov.info"
+    mkdir -p "$artifactDir/$artifactGroup"
+    cp "$lcovFile" "$artifactDir/$artifactGroup/$uploadName.lcov.info"
 }
 
 "$@"

--- a/tools/ci-steps.sh
+++ b/tools/ci-steps.sh
@@ -184,6 +184,68 @@ function _printAndroidState() {
     echo "=== End Android device state ==="
 }
 
+function _printAndroidDriveHeartbeat() {
+    if [[ "$targetOs" != "Android" || -z "${ANDROID_HOME:-}" ]]; then
+        return 0
+    fi
+
+    local adb="$ANDROID_HOME/platform-tools/adb"
+
+    echo "=== Android flutter drive heartbeat $(date -u '+%Y-%m-%dT%H:%M:%SZ') ==="
+    "$adb" devices -l 2>&1 || true
+    "$adb" -s "emulator-5554" get-state 2>&1 || true
+    "$adb" -s "emulator-5554" shell getprop sys.boot_completed 2>&1 || true
+    "$adb" -s "emulator-5554" shell getprop dev.bootcomplete 2>&1 || true
+    "$adb" -s "emulator-5554" shell pidof "$testAppBundleId" 2>&1 || true
+    "$adb" -s "emulator-5554" shell cmd package list packages "$testAppBundleId" 2>&1 || true
+    "$adb" -s "emulator-5554" shell dumpsys activity top 2>&1 | head -n 80 || true
+    "$adb" -s "emulator-5554" logcat -d -t 120 2>&1 || true
+    pgrep -af 'flutter|adb|gradle|java|qemu' || true
+    echo "=== End Android flutter drive heartbeat ==="
+}
+
+function _runFlutterDrive() {
+    local driveVerboseFlag="${1:-}"
+    local dartDefineArgs=()
+    read -r -a dartDefineArgs <<< "$DART_DEFINES"
+
+    local flutterDriveCommand=(
+        flutter drive
+        -d "$device"
+        "${dartDefineArgs[@]}"
+    )
+    [ -n "$noBuildFlag" ] && flutterDriveCommand+=("$noBuildFlag")
+    flutterDriveCommand+=(
+        --keep-app-running
+        --driver test_driver/integration_test.dart
+        --target integration_test/e2e_test.dart
+    )
+    [ -n "$driveVerboseFlag" ] && flutterDriveCommand+=("$driveVerboseFlag")
+
+    if [ "$targetOs" != "Android" ]; then
+        "${flutterDriveCommand[@]}"
+        return
+    fi
+
+    "${flutterDriveCommand[@]}" &
+
+    local drivePid=$!
+    local driveStatus=0
+    local secondsSinceHeartbeat=0
+
+    while kill -0 "$drivePid" 2>/dev/null; do
+        sleep 10
+        secondsSinceHeartbeat=$((secondsSinceHeartbeat + 10))
+        if [ "$secondsSinceHeartbeat" -ge 60 ] && kill -0 "$drivePid" 2>/dev/null; then
+            _printAndroidDriveHeartbeat
+            secondsSinceHeartbeat=0
+        fi
+    done
+
+    wait "$drivePid" || driveStatus=$?
+    return "$driveStatus"
+}
+
 function runE2ETests() {
     requireEnvVar EMBEDDER
     requireEnvVar TARGET_OS
@@ -196,11 +258,13 @@ function runE2ETests() {
         cd "$testPackageDir"
 
         export ENABLE_TIME_BOMB=true
-        testCommand="dart test -r expanded -j 1 --coverage coverage/dart"
+        testCommand="dart test -r expanded -j 1"
 
         if [[ -n "${DART_TEST_PLATFORM:-}" ]]; then
             testCommand="$testCommand -p $DART_TEST_PLATFORM"
             _prepareStandaloneSanitizerNativeAssets
+        else
+            testCommand="$testCommand --coverage coverage/dart"
         fi
 
         case "$targetOs" in
@@ -261,6 +325,10 @@ function runE2ETests() {
 
         local verboseFlag=""
         if isDebug; then verboseFlag="-v"; fi
+        local driveVerboseFlag="$verboseFlag"
+        if [ "$targetOs" = "Android" ]; then
+            driveVerboseFlag="-v"
+        fi
 
         # Build the app explicitly when needed:
         # - iOS: always, because we need the bundle for simulator readiness
@@ -406,14 +474,7 @@ function runE2ETests() {
         if [ "$didExplicitBuild" = true ]; then noBuildFlag="--no-build"; fi
         _printAndroidState
         echo "=== Running Flutter drive for $targetOs ==="
-        flutter drive \
-            -d "$device" \
-            $DART_DEFINES \
-            $noBuildFlag \
-            --keep-app-running \
-            --driver test_driver/integration_test.dart \
-            --target integration_test/e2e_test.dart \
-            $verboseFlag
+        _runFlutterDrive "$driveVerboseFlag"
         echo "=== Finished Flutter drive for $targetOs ==="
         ;;
     esac

--- a/tools/ci-steps.sh
+++ b/tools/ci-steps.sh
@@ -171,6 +171,19 @@ function _prepareStandaloneSanitizerNativeAssets() {
     export LD_PRELOAD="$(IFS=:; echo "${preloadLibs[*]}")"
 }
 
+function _printAndroidState() {
+    if [[ "$targetOs" != "Android" || -z "${ANDROID_HOME:-}" ]]; then
+        return 0
+    fi
+
+    echo "=== Android device state ==="
+    "$ANDROID_HOME/platform-tools/adb" devices -l 2>&1 || true
+    "$ANDROID_HOME/platform-tools/adb" -s "emulator-5554" shell getprop sys.boot_completed 2>&1 || true
+    "$ANDROID_HOME/platform-tools/adb" -s "emulator-5554" shell getprop dev.bootcomplete 2>&1 || true
+    "$ANDROID_HOME/platform-tools/adb" -s "emulator-5554" shell cmd package list packages "$testAppBundleId" 2>&1 || true
+    echo "=== End Android device state ==="
+}
+
 function runE2ETests() {
     requireEnvVar EMBEDDER
     requireEnvVar TARGET_OS
@@ -254,6 +267,8 @@ function runE2ETests() {
         # Build the app explicitly when needed:
         # - iOS: always, because we need the bundle for simulator readiness
         #   checks before flutter drive.
+        # - Android: always, so Gradle/build hangs are visible separately from
+        #   device launch and driver waits.
         # - Debug mode: always, so we can inspect the bundle afterwards.
         # Otherwise, let flutter drive handle the build implicitly.
         local buildTarget
@@ -270,10 +285,17 @@ function runE2ETests() {
         iOS) buildFlags="--simulator --no-codesign" ;;
         esac
         local didExplicitBuild=false
-        if [ "$targetOs" = "iOS" ] || isDebug; then
+        if [ "$targetOs" = "iOS" ] || [ "$targetOs" = "Android" ] || isDebug; then
             echo "=== Building Flutter app for $targetOs ==="
-            flutter build "$buildTarget" --debug $buildFlags $verboseFlag $DART_DEFINES 2>&1
+            flutter build "$buildTarget" \
+                --debug \
+                --target integration_test/e2e_test.dart \
+                $buildFlags \
+                $verboseFlag \
+                $DART_DEFINES \
+                2>&1
             didExplicitBuild=true
+            echo "=== Finished building Flutter app for $targetOs ==="
         fi
 
         if isDebug; then
@@ -384,6 +406,8 @@ function runE2ETests() {
         # flag, which we need to collect logs from devices.
         local noBuildFlag=""
         if [ "$didExplicitBuild" = true ]; then noBuildFlag="--no-build"; fi
+        _printAndroidState
+        echo "=== Running Flutter drive for $targetOs ==="
         flutter drive \
             -d "$device" \
             $DART_DEFINES \
@@ -392,6 +416,7 @@ function runE2ETests() {
             --driver test_driver/integration_test.dart \
             --target integration_test/e2e_test.dart \
             $verboseFlag
+        echo "=== Finished Flutter drive for $targetOs ==="
         ;;
     esac
 }
@@ -451,7 +476,14 @@ function _collectCrashReportsAndroid() {
         echo "Android emulator is not reachable, skipping bugreport collection"
         return 0
     fi
-    ./tools/android-emulator.sh bugreport -o "$testResultsDir"
+
+    if command -v timeout >/dev/null 2>&1; then
+        timeout 90s ./tools/android-emulator.sh bugreport -o "$testResultsDir" || \
+            echo "Android bugreport collection failed or timed out"
+    else
+        ./tools/android-emulator.sh bugreport -o "$testResultsDir" || \
+            echo "Android bugreport collection failed"
+    fi
 }
 
 function _collectCblLogsStandalone() {
@@ -510,9 +542,52 @@ function _collectCblLogsAndroid() {
         echo "Android emulator is not reachable, skipping app data collection"
         return 0
     fi
-    ./tools/android-emulator.sh copyAppData
+    ./tools/android-emulator.sh copyAppData || {
+        echo "Android app data collection failed"
+        return 0
+    }
     zip -r appData.zip appData
     mv appData.zip "$testResultsDir"
+}
+
+function _collectAndroidDiagnostics() {
+    echo "Collecting Android diagnostics"
+
+    local outputDir="$testResultsDir/android"
+    mkdir -p "$outputDir"
+
+    if [[ -n "${ANDROID_HOME:-}" ]]; then
+        "$ANDROID_HOME/platform-tools/adb" devices -l >"$outputDir/adb-devices.txt" 2>&1 || true
+    fi
+
+    if ! _isAndroidEmulatorReachable; then
+        echo "Android emulator is not reachable, skipping emulator diagnostics"
+        return 0
+    fi
+
+    ./tools/android-emulator.sh diagnostics -o "$outputDir" || \
+        echo "Android diagnostics collection failed"
+}
+
+function _collectProcessList() {
+    local name="${1:-processes}"
+
+    echo "Collecting process list"
+    ps -ef >"$testResultsDir/$name.txt" 2>&1 || true
+}
+
+function _collectGradleDiagnostics() {
+    echo "Collecting Gradle diagnostics"
+
+    local outputDir="$testResultsDir/gradle"
+    mkdir -p "$outputDir"
+
+    if [[ -d "$HOME/.gradle/daemon" ]]; then
+        tar -czf "$outputDir/daemon-logs.tar.gz" -C "$HOME/.gradle" daemon 2>&1 || \
+            echo "Gradle daemon log collection failed"
+    else
+        echo "No Gradle daemon directory found"
+    fi
 }
 
 function _collectCblLogsLinux() {
@@ -591,11 +666,14 @@ function collectTestResults() {
     requireEnvVar TARGET_OS
     requireEnvVar TEST_PACKAGE
 
-    mkdir "$testResultsDir"
+    mkdir -p "$testResultsDir"
+
+    _collectProcessList processes-before-wait
 
     # Wait for crash reports/core dumps.
     sleep 60
 
+    _collectProcessList processes-after-wait
     _collectCouchbaseServerLogs
     _collectSyncGatewayLogs
 
@@ -629,6 +707,8 @@ function collectTestResults() {
             _collectCblLogsIosSimulator
             ;;
         Android)
+            _collectGradleDiagnostics
+            _collectAndroidDiagnostics
             _collectCrashReportsAndroid
             _collectCblLogsAndroid
             ;;

--- a/tools/ci-steps.sh
+++ b/tools/ci-steps.sh
@@ -672,17 +672,11 @@ function checkBuildRunnerOutput() {
     exit 1
 }
 
-# Uploads coverage data to codecov.
-#
-# The first and only parameter is a comma separated list of flags to be
-# associated with the uploaded coverage data.
-function uploadCoverageData() {
+# Formats coverage data as lcov.
+function formatCoverageData() {
     requireEnvVar EMBEDDER
     requireEnvVar TEST_PACKAGE
 
-    local flags="$1"
-
-    # Format coverage data as lcov
     case "$embedder" in
     standalone)
         ./tools/coverage.sh dartToLcov "$testPackageDir"
@@ -692,37 +686,21 @@ function uploadCoverageData() {
         # location.
         ;;
     esac
+}
 
-    # Install codecov uploader
-    case "$OSTYPE" in
-    linux*)
-        retry 3 10 curl --fail -Os https://cli.codecov.io/latest/linux/codecov
-        chmod +x codecov
-        ;;
-    darwin*)
-        retry 3 10 curl --fail -Os https://cli.codecov.io/latest/macos/codecov
-        chmod +x codecov
-        ;;
-    mingw* | msys* | cygwin*)
-        retry 3 10 curl --fail -Os https://cli.codecov.io/latest/windows/codecov.exe
-        ;;
-    esac
+# Collects coverage data in a repository-root artifact directory.
+#
+# The first parameter is the unique upload name.
+# The second parameter is a comma separated list of Codecov flags.
+function collectCoverageData() {
+    local uploadName="$1"
+    local flags="$2"
+    local artifactDir="${COVERAGE_ARTIFACTS_DIR:-coverage-artifacts}"
 
-    # Upload coverage data
-    local codecovArgs=(
-        --verbose
-        upload-process
-        --fail-on-error
-        --flag "$flags"
-        --file "$testPackageDir/coverage/lcov.info"
-        --commit-sha "$GITHUB_SHA"
-    )
+    formatCoverageData
 
-    if [[ -n "${CODECOV_BRANCH:-}" ]]; then
-        codecovArgs+=(--branch "$CODECOV_BRANCH")
-    fi
-
-    ./codecov "${codecovArgs[@]}"
+    mkdir -p "$artifactDir/$flags"
+    cp "$testPackageDir/coverage/lcov.info" "$artifactDir/$flags/$uploadName.lcov.info"
 }
 
 "$@"

--- a/tools/ci-steps.sh
+++ b/tools/ci-steps.sh
@@ -768,6 +768,21 @@ function formatCoverageData() {
     esac
 }
 
+function _hasCoverageInput() {
+    case "$embedder" in
+    standalone)
+        [ -d "$testPackageDir/coverage/dart" ] && \
+            find "$testPackageDir/coverage/dart" -type f | grep -q .
+        ;;
+    flutter)
+        [ -f "$testPackageDir/coverage/lcov.info" ]
+        ;;
+    *)
+        return 1
+        ;;
+    esac
+}
+
 # Collects coverage data in a repository-root artifact directory.
 #
 # The first parameter is the unique upload name.
@@ -776,11 +791,35 @@ function collectCoverageData() {
     local uploadName="$1"
     local flags="$2"
     local artifactDir="${COVERAGE_ARTIFACTS_DIR:-coverage-artifacts}"
+    local allowMissing="${ALLOW_MISSING_COVERAGE:-false}"
 
-    formatCoverageData
+    if ! _hasCoverageInput; then
+        echo "Did not find coverage input for $uploadName"
+        if [ "$allowMissing" = true ]; then
+            return 0
+        fi
+        return 1
+    fi
+
+    if ! formatCoverageData; then
+        echo "Failed to format coverage data for $uploadName"
+        if [ "$allowMissing" = true ]; then
+            return 0
+        fi
+        return 1
+    fi
+
+    local lcovFile="$testPackageDir/coverage/lcov.info"
+    if [ ! -f "$lcovFile" ]; then
+        echo "Did not find formatted coverage data at $lcovFile"
+        if [ "$allowMissing" = true ]; then
+            return 0
+        fi
+        return 1
+    fi
 
     mkdir -p "$artifactDir/$flags"
-    cp "$testPackageDir/coverage/lcov.info" "$artifactDir/$flags/$uploadName.lcov.info"
+    cp "$lcovFile" "$artifactDir/$flags/$uploadName.lcov.info"
 }
 
 "$@"


### PR DESCRIPTION
## Summary
- Replace per-job Codecov uploads with a final `upload-coverage` job that downloads coverage artifacts, prepares LCOV reports per flag combination, uploads them through `codecov/codecov-action@v5`, and manually triggers Codecov notifications after uploads complete.
- Model packages as Codecov components (`cbl`, `cbl_sentry`, `cbl_generator`) while using orthogonal flags for test type, runtime, and platform such as `unit`, `e2e`, `runtime.vm`, and `platform.ubuntu`.
- Preserve partial PR coverage when a test or build matrix leg fails by collecting and uploading whatever coverage artifacts were produced, with Codecov carryforward enabled for missing flags.
- Keep `vm-asan` out of coverage uploads for now, since the current runner does not produce usable coverage input for that test platform.
- Add Android Flutter E2E diagnostics and clearer build/run log boundaries, including verbose `flutter drive` output and periodic Android state snapshots while the drive command is still running.
