### PR TITLE
refactor(cbl): Harden outbound FFI struct initialization

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -169,6 +169,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.49.2.tgz",
       "integrity": "sha512-y1IOpG6OSmTpGg/CT0YBb/EAhR2nsC18QWp9Jy8HO9iGySpcwaTvs5kHa17daP3BMTwWyaX9/1tDTDQshZzXdg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.49.2",
         "@algolia/requester-browser-xhr": "5.49.2",
@@ -307,6 +308,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -2018,6 +2020,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2040,6 +2043,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2149,6 +2153,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2570,6 +2575,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3562,6 +3568,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
       "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/logger": "3.9.2",
@@ -4563,6 +4570,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -5026,6 +5034,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -5379,6 +5388,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5720,6 +5730,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5775,6 +5786,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5820,6 +5832,7 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.49.2.tgz",
       "integrity": "sha512-1K0wtDaRONwfhL4h8bbJ9qTjmY6rhGgRvvagXkMBsAOMNr+3Q2SffHECh9DIuNVrMA1JwA0zCwhyepgBZVakng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.15.2",
         "@algolia/client-abtesting": "5.49.2",
@@ -6290,6 +6303,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7249,6 +7263,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -8625,6 +8640,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13066,6 +13082,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13610,6 +13627,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14525,6 +14543,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -15351,6 +15370,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15360,6 +15380,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15415,6 +15436,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -15443,6 +15465,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -17236,7 +17259,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -17317,6 +17341,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17676,6 +17701,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -17874,6 +17900,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.7.tgz",
       "integrity": "sha512-CNqKBRMQjwcmKR0idID5va1qlhrqVUKpovi+Ec79ksW8ux7iS1+A6VqzfZXgVYCFRKl7XL5ap3ZoMpwBJxcg0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",

--- a/packages/cbl/lib/src/bindings/collection.dart
+++ b/packages/cbl/lib/src/bindings/collection.dart
@@ -261,7 +261,9 @@ final class CollectionBindings {
   static Pointer<cblitedart.CBLDart_CBLIndexSpec> _createIndexSpec(
     CBLIndexSpec spec,
   ) {
-    final result = globalArena<cblitedart.CBLDart_CBLIndexSpec>();
+    final result = zeroedGlobalArena<cblitedart.CBLDart_CBLIndexSpec>(
+      sizeOf<cblitedart.CBLDart_CBLIndexSpec>(),
+    );
     final ref = result.ref
       ..type = spec.type.value
       ..expressionLanguage = spec.expressionLanguage.value

--- a/packages/cbl/lib/src/bindings/database.dart
+++ b/packages/cbl/lib/src/bindings/database.dart
@@ -78,7 +78,9 @@ final class DatabaseBindings {
   static CBLEncryptionKey encryptionKeyFromPassword(String password) {
     ensureInitializedForCurrentIsolate();
     return withGlobalArena(() {
-      final key = globalArena<cblite.CBLEncryptionKey>();
+      final key = zeroedGlobalArena<cblite.CBLEncryptionKey>(
+        sizeOf<cblite.CBLEncryptionKey>(),
+      );
       if (!cblite.CBLEncryptionKey_FromPassword(
         key,
         password.makeGlobalFLString(),
@@ -215,7 +217,9 @@ final class DatabaseBindings {
     CBLEncryptionKey? key,
   ) {
     withGlobalArena(() {
-      final keyStruct = globalArena<cblite.CBLEncryptionKey>();
+      final keyStruct = zeroedGlobalArena<cblite.CBLEncryptionKey>(
+        sizeOf<cblite.CBLEncryptionKey>(),
+      );
       _writeEncryptionKey(keyStruct.ref, from: key);
       cblite.CBLDatabase_ChangeEncryptionKey(
         db,
@@ -253,6 +257,10 @@ final class DatabaseBindings {
     cblite.CBLEncryptionKey to, {
     CBLEncryptionKey? from,
   }) {
+    for (var i = 0; i < cblite.kCBLEncryptionKeySizeAES256; i++) {
+      to.bytes[i] = 0;
+    }
+
     if (from == null) {
       to.algorithm = cblite.kCBLEncryptionNone;
       return;
@@ -284,12 +292,17 @@ final class DatabaseBindings {
       return nullptr;
     }
 
-    final result = globalArena<cblitedart.CBLDart_CBLDatabaseConfiguration>();
+    final result =
+        zeroedGlobalArena<cblitedart.CBLDart_CBLDatabaseConfiguration>(
+          sizeOf<cblitedart.CBLDart_CBLDatabaseConfiguration>(),
+        );
 
     result.ref.directory = config.directory.toFLString();
 
     if (cblitedart.CBLDart_IsEnterprise()) {
-      final key = globalArena<cblitedart.CBLDart_CBLEncryptionKey>();
+      final key = zeroedGlobalArena<cblitedart.CBLDart_CBLEncryptionKey>(
+        sizeOf<cblitedart.CBLDart_CBLEncryptionKey>(),
+      );
       _writeEncryptionKey(
         key.cast<cblite.CBLEncryptionKey>().ref,
         from: config.encryptionKey,

--- a/packages/cbl/lib/src/bindings/global.dart
+++ b/packages/cbl/lib/src/bindings/global.dart
@@ -8,6 +8,12 @@ import 'slice.dart';
 
 final globalArena = Arena(cachedSliceResultAllocator);
 
+Pointer<T> zeroedGlobalArena<T extends NativeType>(int byteCount) {
+  final result = globalArena.allocate<T>(byteCount);
+  result.cast<Uint8>().asTypedList(byteCount).fillRange(0, byteCount, 0);
+  return result;
+}
+
 T withGlobalArena<T>(T Function() f) {
   try {
     return f();

--- a/packages/cbl/lib/src/bindings/logging.dart
+++ b/packages/cbl/lib/src/bindings/logging.dart
@@ -194,7 +194,9 @@ final class LoggingBindings {
       return nullptr;
     }
 
-    final result = globalArena<cblite.CBLFileLogSink>();
+    final result = zeroedGlobalArena<cblite.CBLFileLogSink>(
+      sizeOf<cblite.CBLFileLogSink>(),
+    );
 
     result.ref
       ..level = config.level.value

--- a/packages/cbl/lib/src/bindings/replicator.dart
+++ b/packages/cbl/lib/src/bindings/replicator.dart
@@ -458,7 +458,9 @@ final class ReplicatorBindings {
   static Pointer<cblitedart.CBLDart_ReplicatorConfiguration>
   _createConfigurationStruct(CBLReplicatorConfiguration config) {
     final configStruct =
-        globalArena<cblitedart.CBLDart_ReplicatorConfiguration>();
+        zeroedGlobalArena<cblitedart.CBLDart_ReplicatorConfiguration>(
+          sizeOf<cblitedart.CBLDart_ReplicatorConfiguration>(),
+        );
 
     configStruct.ref
       ..database = config.database
@@ -487,8 +489,9 @@ final class ReplicatorBindings {
       ..acceptParentDomainCookies = config.acceptParentDomainCookies;
 
     final collectionStructs =
-        globalArena<cblitedart.CBLDart_ReplicationCollection>(
-          config.collections.length,
+        zeroedGlobalArena<cblitedart.CBLDart_ReplicationCollection>(
+          sizeOf<cblitedart.CBLDart_ReplicationCollection>() *
+              config.collections.length,
         );
 
     configStruct.ref
@@ -515,7 +518,9 @@ final class ReplicatorBindings {
       return nullptr;
     }
 
-    final settingsStruct = globalArena<cblite.CBLProxySettings>();
+    final settingsStruct = zeroedGlobalArena<cblite.CBLProxySettings>(
+      sizeOf<cblite.CBLProxySettings>(),
+    );
 
     settingsStruct.ref
       ..type = settings.type.value

--- a/packages/cbl/lib/src/bindings/url_endpoint_listener.dart
+++ b/packages/cbl/lib/src/bindings/url_endpoint_listener.dart
@@ -59,7 +59,10 @@ final class UrlEndpointListenerBindings {
   }) {
     ensureInitializedForCurrentIsolate();
     return withGlobalArena(() {
-      final config = globalArena<cblite.CBLURLEndpointListenerConfiguration>();
+      final config =
+          zeroedGlobalArena<cblite.CBLURLEndpointListenerConfiguration>(
+            sizeOf<cblite.CBLURLEndpointListenerConfiguration>(),
+          );
 
       final collectionsArray = globalArena<Pointer<cblite.CBLCollection>>(
         collections.length,

--- a/packages/cbl/test/bindings/global_test.dart
+++ b/packages/cbl/test/bindings/global_test.dart
@@ -1,0 +1,27 @@
+import 'dart:ffi';
+
+import 'package:cbl/src/bindings/cblite.dart' as cblite;
+import 'package:cbl/src/bindings/global.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('zeroedGlobalArena clears reused scratch memory', () {
+    late final int address;
+
+    withGlobalArena(() {
+      final slice = globalArena<cblite.FLSlice>();
+      address = slice.address;
+      slice.ref
+        ..buf = Pointer.fromAddress(1)
+        ..size = 42;
+    });
+
+    withGlobalArena(() {
+      final slice = zeroedGlobalArena<cblite.FLSlice>(sizeOf<cblite.FLSlice>());
+
+      expect(slice.address, address);
+      expect(slice.ref.buf, nullptr);
+      expect(slice.ref.size, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Zero-initialize reused arena memory before writing outbound config/spec structs.
- Apply the hardening to database, replicator, URL endpoint listener, collection index, and file log bindings.
- Clear encryption key bytes defensively before writing new values.
- Add a regression test that proves reused scratch memory is cleared before reuse; verified with analyzer plus focused unit and E2E coverage for the touched FFI paths.

Fixes #941
