### PR TITLE
docs: document CBL 4 sync compatibility

### DIFF
--- a/docs/docs/data-sync/peer-to-peer/websocket.mdx
+++ b/docs/docs/data-sync/peer-to-peer/websocket.mdx
@@ -77,6 +77,16 @@ configuration in [Basic Setup](#basic-setup).
 For the step-by-step listener and replicator setup for this transport mode, see
 [Passive Peer](./passive-peer.mdx) and [Active Peer](./active-peer.mdx).
 
+### Version Compatibility
+
+Peer-to-peer sync with Couchbase Lite for Dart v4 requires Couchbase Lite v4 on
+both sides of the connection. A v4 active peer cannot sync with a Couchbase Lite
+3.x listener, and a v4 listener cannot sync with a 3.x active peer.
+
+This requirement comes from Couchbase Lite 4's move from revision trees to
+version vectors. For server-based sync compatibility, see
+[Data Sync using Sync Gateway](../replication.mdx#version-compatibility).
+
 ## Features
 
 Couchbase Lite for Dart's Peer-to-Peer synchronization solution provides support

--- a/docs/docs/data-sync/replication.mdx
+++ b/docs/docs/data-sync/replication.mdx
@@ -47,6 +47,28 @@ The protocol is optimized for throughput, so document delivery order is not
 guaranteed. Avoid application logic that depends on a particular arrival order
 in replication callbacks.
 
+## Version Compatibility
+
+Couchbase Lite for Dart v4 uses version vectors for document versioning and
+replication. Because of that architecture change, v4 clients require Sync
+Gateway 4.0 or later. Attempts to sync with older Sync Gateway versions fail
+with a replication error.
+
+When Sync Gateway 4.0 participates in Couchbase Server XDCR interoperability,
+Couchbase Server 7.6.6 or later is required. Couchbase Lite 3.x clients can
+still sync with Sync Gateway 4.0, but they do not support the cluster-switching
+capabilities that v4 clients gain from version vectors.
+
+For peer-to-peer sync, both peers must run Couchbase Lite v4. Sync between a v4
+peer and a 3.x peer is not supported. See
+[Active-Passive Peer-to-Peer Sync](./peer-to-peer/websocket.mdx) for the
+listener and active peer setup.
+
+For more background, see Couchbase's
+[Version Vectors](https://docs.couchbase.com/couchbase-lite/current/c/version-vectors.html)
+documentation and the
+[Sync Gateway 4.0 compatibility notes](https://docs.couchbase.com/sync-gateway/current/whatsnew.html#compatibility).
+
 ## Scopes and Collections
 
 The local collections configured in the replicator must also exist in Sync

--- a/docs/docs/migration-v3-to-v4.mdx
+++ b/docs/docs/migration-v3-to-v4.mdx
@@ -3,6 +3,8 @@ description: Migrating from Couchbase Lite for Dart v3 to v4
 related_content:
   - name: Install
     url: /install
+  - name: Data Sync
+    url: /data-sync/replication
   - name: Vector Search
     url: /search/vector-search
 ---
@@ -16,6 +18,30 @@ powered by
 [Dart native assets](https://dart.dev/interop/c-interop#native-assets). Native
 libraries are now downloaded and compiled automatically by the Dart build system
 — no manual setup or separate platform packages are needed.
+
+Version 4 also adopts Couchbase Lite 4's version vector architecture. Version
+vectors replace revision trees for document versioning, synchronization, and
+conflict resolution. This is a one-way database migration: once a database has
+been opened and upgraded by Couchbase Lite for Dart v4, it cannot be opened
+again by Couchbase Lite 3.x.
+
+If your application synchronizes data, upgrade the server and peer environment
+before rolling out v4 clients:
+
+- Sync Gateway 4.0 or later is required. Couchbase Lite for Dart v4 cannot sync
+  with earlier Sync Gateway versions.
+- Couchbase Server 7.6.6 or later is required when using XDCR interoperability
+  with Sync Gateway 4.0.
+- Peer-to-peer sync requires Couchbase Lite v4 on both sides. Syncing a v4 peer
+  with a 3.x peer is not supported.
+- Existing Couchbase Lite 3.x clients can still sync with Sync Gateway 4.0, but
+  they do not support the cluster-switching capabilities introduced by the v4
+  version vector model.
+
+For more detail, see Couchbase's
+[Version Vectors](https://docs.couchbase.com/couchbase-lite/current/c/version-vectors.html)
+documentation and the
+[Sync Gateway 4.0 compatibility notes](https://docs.couchbase.com/sync-gateway/current/whatsnew.html#compatibility).
 
 ## Package changes
 
@@ -535,41 +561,44 @@ No manual steps are required.
      `import 'package:cbl/cbl.dart'`.
    - Replace `import 'package:cbl_dart/cbl_dart.dart'` with
      `import 'package:cbl/cbl.dart'`.
-6. **Remove initialization**: Remove calls to `CouchbaseLiteFlutter.init()` or
+6. **Plan sync compatibility**: upgrade Sync Gateway to 4.0 or later before v4
+   clients sync, use Couchbase Server 7.6.6 or later for XDCR interoperability
+   with Sync Gateway 4.0, and keep peer-to-peer sync between v4 peers.
+7. **Remove initialization**: Remove calls to `CouchbaseLiteFlutter.init()` or
    `CouchbaseLiteDart.init(...)`. Initialization is no longer required. If you
    customized the default database directory via the `filesDir` parameter, use
    `api|Database.defaultDirectory` instead.
-7. **Enable vector search** (if needed) via `pubspec.yaml` config and an
+8. **Enable vector search** (if needed) via `pubspec.yaml` config and an
    explicit call to `api|Extension.enableVectorSearch`.
-8. **Rename `langauge`** to `language` on `FullTextIndex`.
-9. **Update certificate fields** on `ReplicatorConfiguration` — wrap
-   `pinnedServerCertificate` bytes with `DerData` or `PemData`, and
-   `trustedRootCertificates` bytes with `PemData`.
-10. **Update `MutableDocument` constructors** — replace `MutableDocument()` with
+9. **Rename `langauge`** to `language` on `FullTextIndex`.
+10. **Update certificate fields** on `ReplicatorConfiguration` — wrap
+    `pinnedServerCertificate` bytes with `DerData` or `PemData`, and
+    `trustedRootCertificates` bytes with `PemData`.
+11. **Update `MutableDocument` constructors** — replace `MutableDocument()` with
     `MutableDocument({})` and `MutableDocument.withId(id, data)` with
     `MutableDocument(id: id, data)`.
-11. **Rename `maxRotateCount`** to `maxKeptFiles` in any `LogFileConfiguration`
+12. **Rename `maxRotateCount`** to `maxKeptFiles` in any `LogFileConfiguration`
     usage.
-12. **Update query result checks** that compare boolean expressions against `1`
+13. **Update query result checks** that compare boolean expressions against `1`
     or `0` — they now return `true`/`false`.
-13. **Remove hardcoded revision IDs** — revision IDs are no longer
+14. **Remove hardcoded revision IDs** — revision IDs are no longer
     deterministic.
-14. **Review conflict resolution logic** — `DefaultConflictResolver` now uses
+15. **Review conflict resolution logic** — `DefaultConflictResolver` now uses
     timestamp comparison instead of revision ID comparison.
-15. **Update conflict handling** — `saveDocument` and `deleteDocument` with
+16. **Update conflict handling** — `saveDocument` and `deleteDocument` with
     `failOnConflict` now throw `DatabaseException` instead of returning `false`.
-16. **Migrate Database document/index/listener APIs** to use `defaultCollection`
+17. **Migrate Database document/index/listener APIs** to use `defaultCollection`
     methods instead.
-17. **Migrate ReplicatorConfiguration** — replace `database` parameter with
+18. **Migrate ReplicatorConfiguration** — replace `database` parameter with
     `addCollection`, move `channels`/`documentIds`/filters/resolvers into
     `CollectionConfiguration`.
-18. **Migrate Replicator pending document APIs** — replace
+19. **Migrate Replicator pending document APIs** — replace
     `pendingDocumentIds`/`isDocumentPending` with
     `pendingDocumentIdsInCollection`/`isDocumentPendingInCollection`.
-19. **Replace `DataSource.database(db)`** with
+20. **Replace `DataSource.database(db)`** with
     `DataSource.collection(collection)`.
-20. **Replace `InvalidJsonException`** with `FleeceException`.
-21. **Remove `TracingDelegate` usage** — the tracing API has been removed from
+21. **Replace `InvalidJsonException`** with `FleeceException`.
+22. **Remove `TracingDelegate` usage** — the tracing API has been removed from
     the public API.
-22. **Run your app** — native libraries will be built automatically on first
+23. **Run your app** — native libraries will be built automatically on first
     run.

--- a/docs/docs/supported-platforms.mdx
+++ b/docs/docs/supported-platforms.mdx
@@ -19,6 +19,26 @@ Couchbase Lite for Dart requires Dart SDK `^3.10.0`.
 |    Linux | >= Ubuntu 20.04 x86_64 |
 |  Windows | >= 10 x86_64           |
 
+## Sync compatibility
+
+Couchbase Lite for Dart v4 uses Couchbase Lite 4's version vector architecture.
+Plan sync deployments around these requirements:
+
+- Sync Gateway 4.0 or later is required for Couchbase Lite for Dart v4 clients.
+  Older Sync Gateway versions are not supported.
+- Couchbase Server 7.6.6 or later is required when using XDCR interoperability
+  with Sync Gateway 4.0.
+- Peer-to-peer sync requires Couchbase Lite v4 on both sides of the connection.
+  Syncing with Couchbase Lite 3.x peers is not supported.
+- Couchbase Lite 3.x clients can still sync with Sync Gateway 4.0, but they do
+  not support v4 cluster-switching behavior.
+- Database upgrades to version vectors are one-way. After a database is opened
+  by Couchbase Lite for Dart v4, Couchbase Lite 3.x cannot open it again.
+
+For more detail, see
+[Data Sync using Sync Gateway](./data-sync/replication.mdx#version-compatibility)
+and the [v3 to v4 migration guide](./migration-v3-to-v4.mdx).
+
 ## Default database directory
 
 When opening a database without specifying a directory, Couchbase Lite uses


### PR DESCRIPTION
## Summary

Documents the Couchbase Lite 4 version-vector compatibility requirements across the migration, Sync Gateway replication, peer-to-peer sync, and supported-platforms docs. The update calls out the required Sync Gateway 4.0+ baseline, Couchbase Server 7.6.6+ for XDCR interoperability, v4-only peer-to-peer sync, CBL 3.x client limitations with Sync Gateway 4.0, and one-way database upgrades.

The docs were formatted with Prettier and the Docusaurus production build was run successfully.