### PR TITLE
test(cbl_generator): stabilize flaky bad-source tests

### DIFF
--- a/packages/cbl_generator/test/generator/generator_test_utils.dart
+++ b/packages/cbl_generator/test/generator/generator_test_utils.dart
@@ -1,0 +1,246 @@
+// coverage:ignore-file
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+
+const _diagnosticsEnv = 'CBL_GENERATOR_TEST_DIAGNOSTICS';
+const _slowBuildMsEnv = 'CBL_GENERATOR_SLOW_BUILD_MS';
+const _stressEnv = 'CBL_GENERATOR_STRESS';
+const _stressIterationsEnv = 'CBL_GENERATOR_STRESS_ITERATIONS';
+
+var _nextBuildInvocationId = 0;
+var _nextUniqueAssetId = 0;
+
+bool get generatorTestDiagnosticsEnabled =>
+    _isTruthy(Platform.environment[_diagnosticsEnv]);
+
+bool get generatorStressEnabled => _isTruthy(Platform.environment[_stressEnv]);
+
+int generatorStressIterations({int defaultValue = 10}) =>
+    _intFromEnvironment(_stressIterationsEnv, defaultValue: defaultValue);
+
+String uniqueGeneratorAssetStem(String label) {
+  final id = _nextUniqueAssetId++;
+  final sanitized = label
+      .replaceAll(RegExp('[^a-zA-Z0-9]+'), '_')
+      .replaceAll(RegExp(r'^_+|_+$'), '')
+      .toLowerCase();
+  return 'generated/${sanitized}_$id';
+}
+
+Future<TestReaderWriter> createGeneratorTestReaderWriter({
+  required String rootPackage,
+  required String label,
+}) async {
+  final stopwatch = Stopwatch()..start();
+  final readerWriter = TestReaderWriter(rootPackage: rootPackage);
+  Timer? heartbeat;
+
+  void emit(String message) =>
+      _emitDiagnostic('[generator-test-reader-writer] $label $message');
+
+  emit('LOAD_BEGIN rootPackage=$rootPackage');
+  if (generatorTestDiagnosticsEnabled) {
+    heartbeat = Timer.periodic(
+      const Duration(seconds: 15),
+      (_) => emit(
+        'LOAD_RUNNING elapsedMs=${stopwatch.elapsedMilliseconds} '
+        'assets=${readerWriter.testing.assets.length} '
+        'rss=${ProcessInfo.currentRss}',
+      ),
+    );
+  }
+
+  try {
+    await readerWriter.testing.loadIsolateSources();
+    stopwatch.stop();
+    heartbeat?.cancel();
+    emit(
+      'LOAD_END elapsedMs=${stopwatch.elapsedMilliseconds} '
+      'assets=${readerWriter.testing.assets.length} '
+      'rss=${ProcessInfo.currentRss}',
+    );
+    return readerWriter;
+  } on Object catch (error, stackTrace) {
+    stopwatch.stop();
+    heartbeat?.cancel();
+    emit(
+      'LOAD_ERROR elapsedMs=${stopwatch.elapsedMilliseconds} '
+      'assets=${readerWriter.testing.assets.length} error=$error',
+    );
+    emit('LOAD_STACK $stackTrace');
+    rethrow;
+  }
+}
+
+void deleteGeneratorTestAsset(TestReaderWriter readerWriter, String assetId) {
+  final separator = assetId.indexOf('|');
+  if (separator < 0) {
+    throw ArgumentError.value(assetId, 'assetId', 'Expected package|path.');
+  }
+
+  final id = AssetId(
+    assetId.substring(0, separator),
+    assetId.substring(separator + 1),
+  );
+  if (readerWriter.testing.exists(id)) {
+    readerWriter.testing.delete(id);
+  }
+}
+
+Future<TestBuilderResult> runGeneratorTestBuilder(
+  Builder builder,
+  Map<String, Object> sourceAssets, {
+  required String label,
+  TestReaderWriter? readerWriter,
+  Map<String, Object>? outputs,
+  void Function(LogRecord record)? onLog,
+  Duration? slowThreshold,
+}) async {
+  final invocationId = _nextBuildInvocationId++;
+  final stopwatch = Stopwatch()..start();
+  final logs = <LogRecord>[];
+  Timer? heartbeat;
+  final packageConfig =
+      (await PackageAssetReader.currentIsolate()).packageConfig;
+  final effectiveSlowThreshold =
+      slowThreshold ??
+      Duration(
+        milliseconds: _intFromEnvironment(_slowBuildMsEnv, defaultValue: 10000),
+      );
+
+  void emit(String message) => _emitDiagnostic(
+    '[generator-test-builder] #$invocationId $label $message',
+  );
+
+  emit(
+    'BEGIN assets=${_describeAssets(sourceAssets)} '
+    'readerAssets=${_readerAssetCount(readerWriter) ?? 'none'} '
+    'packageConfig=custom',
+  );
+  if (generatorTestDiagnosticsEnabled) {
+    heartbeat = Timer.periodic(
+      const Duration(seconds: 15),
+      (_) => emit(
+        'RUNNING elapsedMs=${stopwatch.elapsedMilliseconds} '
+        'logs=${logs.length}',
+      ),
+    );
+  }
+
+  void captureLog(LogRecord record) {
+    logs.add(record);
+    _emitDiagnostic(
+      '[generator-test-builder] #$invocationId $label '
+      'LOG ${_formatLogRecord(record)}',
+    );
+    onLog?.call(record);
+  }
+
+  try {
+    final result = await testBuilder(
+      builder,
+      sourceAssets,
+      outputs: outputs,
+      onLog: captureLog,
+      readerWriter: readerWriter,
+      packageConfig: packageConfig,
+    );
+
+    stopwatch.stop();
+    heartbeat?.cancel();
+    emit(
+      'END elapsedMs=${stopwatch.elapsedMilliseconds} '
+      'logs=${logs.length} succeeded=${result.succeeded} '
+      'outputs=${result.outputs.length} errors=${result.errors.length}',
+    );
+
+    if (stopwatch.elapsed > effectiveSlowThreshold) {
+      emit('SLOW thresholdMs=${effectiveSlowThreshold.inMilliseconds}');
+    }
+
+    return result;
+  } on Object catch (error, stackTrace) {
+    stopwatch.stop();
+    heartbeat?.cancel();
+    emit(
+      'ERROR elapsedMs=${stopwatch.elapsedMilliseconds} '
+      'logs=${logs.length} error=$error',
+    );
+    emit('STACK $stackTrace');
+    for (final entry in sourceAssets.entries) {
+      emit('SOURCE ${entry.key}\n${entry.value}');
+    }
+    rethrow;
+  }
+}
+
+void _emitDiagnostic(String message) {
+  printOnFailure(message);
+
+  if (generatorTestDiagnosticsEnabled) {
+    stdout.writeln(message);
+  }
+}
+
+String _describeAssets(Map<String, Object> assets) => assets.entries
+    .map((entry) => '${entry.key}#${_stableHash(entry.value)}')
+    .join(',');
+
+int? _readerAssetCount(TestReaderWriter? readerWriter) {
+  if (readerWriter == null) {
+    return null;
+  }
+
+  return readerWriter.testing.assets.length;
+}
+
+String _formatLogRecord(LogRecord record) {
+  final buffer = StringBuffer()
+    ..write(record.time.toIso8601String())
+    ..write(' ')
+    ..write(record.level.name)
+    ..write(' ')
+    ..write(record.loggerName)
+    ..write(' ')
+    ..write(record.message);
+
+  if (record.error != null) {
+    buffer
+      ..write(' error=')
+      ..write(record.error);
+  }
+
+  if (record.stackTrace != null) {
+    buffer
+      ..write(' stack=')
+      ..write(record.stackTrace);
+  }
+
+  return buffer.toString();
+}
+
+String _stableHash(Object value) {
+  var hash = 0x811c9dc5;
+  for (final codeUnit in value.toString().codeUnits) {
+    hash ^= codeUnit;
+    hash = (hash * 0x01000193) & 0xffffffff;
+  }
+  return hash.toRadixString(16).padLeft(8, '0');
+}
+
+int _intFromEnvironment(String name, {required int defaultValue}) {
+  final value = int.tryParse(Platform.environment[name] ?? '');
+  if (value == null || value <= 0) {
+    return defaultValue;
+  }
+  return value;
+}
+
+bool _isTruthy(String? value) =>
+    value != null && value.isNotEmpty && value != '0' && value != 'false';

--- a/packages/cbl_generator/test/generator/typed_database_generator_test.dart
+++ b/packages/cbl_generator/test/generator/typed_database_generator_test.dart
@@ -4,12 +4,16 @@ import 'package:logging/logging.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
+import 'generator_test_utils.dart';
+
 late TestReaderWriter readerWriter;
 
 void main() {
-  setUp(() async {
-    readerWriter = TestReaderWriter(rootPackage: _testPkg);
-    await readerWriter.testing.loadIsolateSources();
+  setUpAll(() async {
+    readerWriter = await createGeneratorTestReaderWriter(
+      rootPackage: _testPkg,
+      label: 'typed_database shared reader',
+    );
   });
 
   test('annotated declaration is not a class', () async {
@@ -28,7 +32,7 @@ class A {
   });
 
   test('database without types', () async {
-    await testBuilder(
+    await runGeneratorTestBuilder(
       TypedDatabaseBuilder(),
       {
         _testLibId: _testLibContent(r'''
@@ -37,8 +41,8 @@ class $A {
 }
 '''),
       },
+      label: 'typed_database database without types',
       readerWriter: readerWriter,
-      packageConfig: (await PackageAssetReader.currentIsolate()).packageConfig,
       outputs: {
         _genPartId: _typedDatabaseGeneratorContent(r'''
 class A extends $A {
@@ -106,13 +110,20 @@ Future<void> _expectBadSource(String source, [Object? messageMatcher]) async {
     }
   }
 
-  await testBuilder(
-    TypedDatabaseBuilder(),
-    {_testLibId: _testLibContent(source)},
-    onLog: captureError,
-    readerWriter: readerWriter,
-    packageConfig: (await PackageAssetReader.currentIsolate()).packageConfig,
-  );
+  final assetStem = uniqueGeneratorAssetStem('typed_database_bad_source');
+  final sourceAsset = '$_testPkg|lib/$assetStem.dart';
+
+  try {
+    await runGeneratorTestBuilder(
+      TypedDatabaseBuilder(),
+      {sourceAsset: _testLibContent(source)},
+      label: 'typed_database bad source',
+      onLog: captureError,
+      readerWriter: readerWriter,
+    );
+  } finally {
+    deleteGeneratorTestAsset(readerWriter, sourceAsset);
+  }
 
   await expectLater(errorMessage, effectiveMatcher ?? isNotNull);
 }

--- a/packages/cbl_generator/test/generator/typed_dictionary_generator_stress_test.dart
+++ b/packages/cbl_generator/test/generator/typed_dictionary_generator_stress_test.dart
@@ -1,0 +1,240 @@
+// coverage:ignore-file
+
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:build_test/build_test.dart';
+import 'package:cbl_generator/src/builder.dart';
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+
+import 'generator_test_utils.dart';
+
+void main() {
+  final iterations = generatorStressIterations();
+
+  group(
+    'typed dictionary generator stress diagnostics',
+    skip: generatorStressEnabled
+        ? false
+        : 'Set CBL_GENERATOR_STRESS=1 to run generator stress diagnostics.',
+    () {
+      test(
+        'metadata bad-source builds stay isolated under repetition',
+        () async {
+          final readerWriter = await createGeneratorTestReaderWriter(
+            rootPackage: _testPkg,
+            label: 'stress shared reader',
+          );
+          final random = math.Random(0);
+          final samples = <_StressSample>[];
+
+          for (var iteration = 0; iteration < iterations; iteration++) {
+            final cases = List.of(_metadataCases)..shuffle(random);
+
+            for (final testCase in cases) {
+              samples.addAll([
+                await _runStressCase(
+                  testCase,
+                  iteration: iteration,
+                  assetMode: _AssetMode.shared,
+                  readerWriter: readerWriter,
+                ),
+                await _runStressCase(
+                  testCase,
+                  iteration: iteration,
+                  assetMode: _AssetMode.unique,
+                  readerWriter: readerWriter,
+                ),
+              ]);
+            }
+          }
+
+          stdout.writeln(_formatSummary(samples));
+        },
+        timeout: Timeout(Duration(minutes: math.max(2, iterations))),
+      );
+    },
+  );
+}
+
+const _testPkg = 'pkg';
+
+const _metadataCases = [
+  _StressCase(
+    name: 'document_id_getter_wrong_type',
+    source: r'''
+@TypedDocument()
+abstract class A with _$A {
+  factory A() = MutableA;
+
+  @DocumentId()
+  int get id;
+}
+''',
+    expectedMessage:
+        '@DocumentId must be used on a getter which returns a String.',
+  ),
+  _StressCase(
+    name: 'document_sequence_getter_wrong_type',
+    source: r'''
+@TypedDocument()
+abstract class A with _$A {
+  factory A() = MutableA;
+
+  @DocumentSequence()
+  String get sequence;
+}
+''',
+    expectedMessage:
+        '@DocumentSequence must be used on a getter which returns a int.',
+  ),
+  _StressCase(
+    name: 'document_revision_id_getter_wrong_type',
+    source: r'''
+@TypedDocument()
+abstract class A with _$A {
+  factory A() = MutableA;
+
+  @DocumentRevisionId()
+  String get sequence;
+}
+''',
+    expectedMessage:
+        '@DocumentRevisionId must be used on a getter which returns a String?.',
+  ),
+];
+
+Future<_StressSample> _runStressCase(
+  _StressCase testCase, {
+  required int iteration,
+  required _AssetMode assetMode,
+  required TestReaderWriter readerWriter,
+}) async {
+  final label =
+      'stress ${assetMode.name} ${testCase.name} iteration=$iteration';
+  final assetStem = switch (assetMode) {
+    _AssetMode.shared => 'generated/stress_${testCase.name}',
+    _AssetMode.unique => uniqueGeneratorAssetStem(
+      'stress_${testCase.name}_$iteration',
+    ),
+  };
+  final assetName = assetStem.split('/').last;
+  final sourceAsset = '$_testPkg|lib/$assetStem.dart';
+  final severeMessages = <String>[];
+  final stopwatch = Stopwatch()..start();
+
+  void captureError(LogRecord record) {
+    if (record.level >= Level.SEVERE) {
+      severeMessages.add(record.message);
+    }
+  }
+
+  try {
+    await runGeneratorTestBuilder(
+      TypedDataBuilder(),
+      {
+        sourceAsset: _testLibContent(
+          testCase.source,
+          partFileName: '$assetName.cbl.type.g.dart',
+        ),
+      },
+      label: label,
+      onLog: captureError,
+      readerWriter: readerWriter,
+    );
+  } finally {
+    deleteGeneratorTestAsset(readerWriter, sourceAsset);
+  }
+  stopwatch.stop();
+
+  expect(
+    severeMessages,
+    hasLength(1),
+    reason: 'Captured severe messages:\n${severeMessages.join('\n---\n')}',
+  );
+  expect(severeMessages.single, contains(testCase.expectedMessage));
+
+  return _StressSample(
+    caseName: testCase.name,
+    assetMode: assetMode,
+    iteration: iteration,
+    elapsed: stopwatch.elapsed,
+  );
+}
+
+String _testLibContent(String content, {required String partFileName}) =>
+    '''
+import 'package:cbl/cbl.dart';
+
+part '$partFileName';
+
+$content''';
+
+String _formatSummary(List<_StressSample> samples) {
+  final buffer = StringBuffer()
+    ..writeln('typed_dictionary_generator_stress summary')
+    ..writeln('samples=${samples.length}')
+    ..writeln(
+      'iterations=${samples.map((sample) => sample.iteration).toSet().length}',
+    );
+
+  for (final assetMode in _AssetMode.values) {
+    for (final testCase in _metadataCases) {
+      final matching = samples
+          .where(
+            (sample) =>
+                sample.assetMode == assetMode &&
+                sample.caseName == testCase.name,
+          )
+          .toList();
+      if (matching.isEmpty) {
+        continue;
+      }
+
+      final totalMs = matching.fold<int>(
+        0,
+        (previous, sample) => previous + sample.elapsed.inMilliseconds,
+      );
+      final maxMs = matching
+          .map((sample) => sample.elapsed.inMilliseconds)
+          .reduce(math.max);
+      buffer.writeln(
+        '${assetMode.name}/${testCase.name}: '
+        'count=${matching.length} '
+        'avgMs=${totalMs ~/ matching.length} '
+        'maxMs=$maxMs',
+      );
+    }
+  }
+
+  return buffer.toString();
+}
+
+enum _AssetMode { shared, unique }
+
+final class _StressCase {
+  const _StressCase({
+    required this.name,
+    required this.source,
+    required this.expectedMessage,
+  });
+
+  final String name;
+  final String source;
+  final String expectedMessage;
+}
+
+final class _StressSample {
+  const _StressSample({
+    required this.caseName,
+    required this.assetMode,
+    required this.iteration,
+    required this.elapsed,
+  });
+
+  final String caseName;
+  final _AssetMode assetMode;
+  final int iteration;
+  final Duration elapsed;
+}

--- a/packages/cbl_generator/test/generator/typed_dictionary_generator_test.dart
+++ b/packages/cbl_generator/test/generator/typed_dictionary_generator_test.dart
@@ -4,12 +4,16 @@ import 'package:logging/logging.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
+import 'generator_test_utils.dart';
+
 late TestReaderWriter readerWriter;
 
 void main() {
-  setUp(() async {
-    readerWriter = TestReaderWriter(rootPackage: _testPkg);
-    await readerWriter.testing.loadIsolateSources();
+  setUpAll(() async {
+    readerWriter = await createGeneratorTestReaderWriter(
+      rootPackage: _testPkg,
+      label: 'typed_dictionary shared reader',
+    );
   });
 
   test('annotated element is not a class', () async {
@@ -68,7 +72,7 @@ abstract class A with _$A {
   });
 
   test('class without fields', () async {
-    await testBuilder(
+    await runGeneratorTestBuilder(
       TypedDataBuilder(),
       {
         _testLibId: _testLibContent(r'''
@@ -78,8 +82,8 @@ abstract class A with _$A {
 }
 '''),
       },
+      label: 'typed_dictionary class without fields',
       readerWriter: readerWriter,
-      packageConfig: (await PackageAssetReader.currentIsolate()).packageConfig,
       outputs: {
         _genPartId: _typedDictionaryGeneratorContent(r'''
 mixin _$A implements TypedDictionaryObject<MutableA> {}
@@ -137,7 +141,7 @@ abstract class A with _$A {
   });
 
   test('class with String field', () async {
-    await testBuilder(
+    await runGeneratorTestBuilder(
       TypedDataBuilder(),
       {
         _testLibId: _testLibContent(r'''
@@ -147,8 +151,8 @@ abstract class A with _$A {
 }
 '''),
       },
+      label: 'typed_dictionary class with String field',
       readerWriter: readerWriter,
-      packageConfig: (await PackageAssetReader.currentIsolate()).packageConfig,
       outputs: {
         _genPartId: _typedDictionaryGeneratorContent(r'''
 mixin _$A implements TypedDictionaryObject<MutableA> {
@@ -334,11 +338,14 @@ const _genPartFileName = '$_testLib.cbl.type.g.dart';
 const _testLibId = '$_testPkg|$_testLibFileName';
 const _genPartId = '$_testPkg|$_genPartFileName';
 
-String _testLibContent(String content) =>
+String _testLibContent(
+  String content, {
+  String partFileName = _genPartFileName,
+}) =>
     '''
 import 'package:cbl/cbl.dart';
 
-part '$_genPartFileName';
+part '$partFileName';
 
 $content''';
 
@@ -377,13 +384,26 @@ Future<void> _expectBadSource(String source, [Object? messageMatcher]) async {
     }
   }
 
-  await testBuilder(
-    TypedDataBuilder(),
-    {_testLibId: _testLibContent(source)},
-    onLog: captureError,
-    readerWriter: readerWriter,
-    packageConfig: (await PackageAssetReader.currentIsolate()).packageConfig,
-  );
+  final assetStem = uniqueGeneratorAssetStem('typed_dictionary_bad_source');
+  final assetName = assetStem.split('/').last;
+  final sourceAsset = '$_testPkg|lib/$assetStem.dart';
+
+  try {
+    await runGeneratorTestBuilder(
+      TypedDataBuilder(),
+      {
+        sourceAsset: _testLibContent(
+          source,
+          partFileName: '$assetName.cbl.type.g.dart',
+        ),
+      },
+      label: 'typed_dictionary bad source',
+      onLog: captureError,
+      readerWriter: readerWriter,
+    );
+  } finally {
+    deleteGeneratorTestAsset(readerWriter, sourceAsset);
+  }
 
   await expectLater(errorMessage, effectiveMatcher ?? isNotNull);
 }


### PR DESCRIPTION
## Summary

Stabilizes the flaky `cbl_generator` bad-source generator tests by sharing a preloaded `TestReaderWriter` per generator test file and per stress run instead of repeatedly creating readers and reloading isolate sources. Each synthetic bad-source asset still gets a unique path and is deleted after the assertion, so failed inputs stay isolated without leaving stale invalid sources behind.

The investigation narrowed the timeout away from Couchbase Lite database code and away from the generator/analyzer work itself. The original stress failure stalled inside `TestReaderWriter.testing.loadIsolateSources()` for several minutes under high runner CPU/memory pressure. After removing the repeated per-case loads, the normal CI matrix exposed the remaining source of flakiness: the generator tests still loaded isolate sources in `setUp()` for every single test. On the small Ubuntu runner, that pushed one bad-source test past Dart test's 30-second default before the builder call really completed; the following resolver error was a consequence of the timed-out run, not the primary failure.

The generator tests now load isolate sources once in `setUpAll()` for `typed_database_generator_test.dart` and `typed_dictionary_generator_test.dart`. The builder diagnostics stay in the test harness via `printOnFailure`, and stdout heartbeat output remains opt-in through `CBL_GENERATOR_TEST_DIAGNOSTICS`. The opt-in typed-dictionary metadata stress diagnostic stays skipped by default unless `CBL_GENERATOR_STRESS=1` is set; it defaults to ten iterations and can be increased with `CBL_GENERATOR_STRESS_ITERATIONS`.

Temporary CI narrowing, coverage disabling, benchmark skipping, and production generator tracing have been removed, so the PR is back on the normal workflow matrix. The diagnosis-only helper and opt-in stress file are excluded from coverage accounting, while the actual generator tests remain covered. The final pushed SHA passed the full CI workflow, the benchmark workflow, Codecov project and patch checks, and the focused local validation used during the investigation (`daco format`, `dart analyze --fatal-infos`, `checkBuildRunnerOutput`, the focused generator tests with coverage and diagnostics, the opt-in 10-iteration stress run, the full `packages/cbl_generator` coverage test command, and LCOV verification that diagnostic-only files are excluded).