### PR TITLE
ci: use one Codecov flag per upload

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -463,7 +463,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           directory: coverage-artifacts/unit.runtime.vm.platform.ubuntu
-          flags: unit,runtime.vm,platform.ubuntu
+          flags: unit.runtime.vm.platform.ubuntu
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -474,7 +474,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           directory: coverage-artifacts/unit.runtime.vm.platform.macos
-          flags: unit,runtime.vm,platform.macos
+          flags: unit.runtime.vm.platform.macos
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -485,7 +485,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           directory: coverage-artifacts/unit.runtime.vm.platform.windows
-          flags: unit,runtime.vm,platform.windows
+          flags: unit.runtime.vm.platform.windows
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -496,7 +496,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           directory: coverage-artifacts/e2e.runtime.vm.platform.ubuntu
-          flags: e2e,runtime.vm,platform.ubuntu
+          flags: e2e.runtime.vm.platform.ubuntu
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -507,7 +507,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           directory: coverage-artifacts/e2e.runtime.vm.platform.macos
-          flags: e2e,runtime.vm,platform.macos
+          flags: e2e.runtime.vm.platform.macos
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -518,7 +518,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           directory: coverage-artifacts/e2e.runtime.vm.platform.windows
-          flags: e2e,runtime.vm,platform.windows
+          flags: e2e.runtime.vm.platform.windows
           override_branch: ${{ env.CODECOV_BRANCH }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov flags are coverage groups, not independent dimension tags. The merged workflow passed values like `unit,runtime.vm,platform.ubuntu` and `e2e,runtime.vm,platform.windows`, which makes each upload appear under multiple flags and triggers Codecov's multiple-flags warning.

This PR keeps the existing artifact grouping but sends one composed flag per upload, for example `e2e.runtime.vm.platform.windows`. I checked the workflow with `actionlint .github/workflows/ci.yaml` and parsed both workflow and Codecov YAML locally.