### PR TITLE
chore: fix analyzer warnings in shared E2E test utilities

### DIFF
--- a/packages/cbl_e2e_tests/lib/src/utils/api_variant.dart
+++ b/packages/cbl_e2e_tests/lib/src/utils/api_variant.dart
@@ -37,7 +37,7 @@ void apiTest(
   variantTest(
     description,
     body,
-    variants: [api, isolate, if (variants != null) ...variants],
+    variants: [api, isolate, ...?variants],
     skip: skip,
   );
 }

--- a/packages/cbl_e2e_tests/lib/src/utils/file_system.dart
+++ b/packages/cbl_e2e_tests/lib/src/utils/file_system.dart
@@ -13,7 +13,7 @@ extension DirectoryExt on Directory {
   }
 
   Future<void> reset() async {
-    if (await exists()) {
+    if (existsSync()) {
       await delete(recursive: true);
     }
     await create(recursive: true);


### PR DESCRIPTION
## Summary
- Replace the nullable spread in `apiTest` with `...?variants` to satisfy the current Dart analyzer.
- Use `Directory.existsSync()` in `reset()` to avoid the async I/O lint triggered by `--fatal-infos`.
- These changes clean up the shared E2E utility code used by both standalone Dart and Flutter test runners.

## Testing
- `melos analyze`
- `daco format` on the updated Dart files