### PR TITLE
ci: tighten Dependabot for workspace dependency bounds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,39 +7,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
-  - package-ecosystem: pub
-    directory: /packages/cbl
-    schedule:
-      interval: weekly
-    versioning-strategy: increase-if-necessary
-  - package-ecosystem: pub
-    directory: /packages/cbl/example
-    schedule:
-      interval: weekly
-  - package-ecosystem: pub
-    directory: /packages/cbl_e2e_tests
-    schedule:
-      interval: weekly
-  - package-ecosystem: pub
-    directory: /packages/cbl_e2e_tests_flutter
-    schedule:
-      interval: weekly
-  - package-ecosystem: pub
-    directory: /packages/cbl_e2e_tests_standalone_dart
-    schedule:
-      interval: weekly
-    versioning-strategy: increase-if-necessary
-  - package-ecosystem: pub
-    directory: /packages/cbl_generator
-    schedule:
-      interval: weekly
-    versioning-strategy: increase-if-necessary
-  - package-ecosystem: pub
-    directory: /packages/cbl_sentry
-    schedule:
-      interval: weekly
-    versioning-strategy: increase-if-necessary
-  - package-ecosystem: pub
-    directory: /packages/cbl_sentry/example
-    schedule:
-      interval: weekly
+    # The root pub updater sees the whole Dart workspace. Keep it from raising
+    # lower bounds in published packages while updating the workspace lockfile.
+    versioning-strategy: widen

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,6 +93,42 @@ jobs:
       - name: Analyze Dart code
         run: melos analyze
 
+  analyze-dart-boundary-versions:
+    name: Analyze Dart code with ${{ matrix.dependency-bound.name }} dependencies
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        dependency-bound:
+          - name: lowest
+            pub-command: downgrade
+          - name: highest
+            pub-command: upgrade
+    runs-on: runs-on=${{ github.run_id }}/runner=ubuntu22-2cpu
+    steps:
+      - uses: runs-on/action@v2
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Flutter
+        uses: ./.github/actions/setup-flutter
+        with:
+          channel: ${{ env.flutter-channel }}
+          cache: true
+          pub-cache-hash-pattern: pubspec.lock
+
+      - name: Resolve ${{ matrix.dependency-bound.name }} dependencies
+        run: dart pub ${{ matrix.dependency-bound.pub-command }}
+
+      - name: Bootstrap repository
+        shell: bash
+        run: dart run melos bootstrap
+
+      - name: Analyze Dart code
+        run: dart run melos analyze
+
   publish-dry-run:
     name: Publish dry run
     timeout-minutes: 10
@@ -398,6 +434,7 @@ jobs:
       - formatting-dart
       - formatting-clang
       - analyze-dart
+      - analyze-dart-boundary-versions
       - publish-dry-run
       - test-dart-unit
       - test-e2e

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,10 +78,29 @@ The build hook at `packages/cbl/hook/build.dart` handles native dependencies:
 Edition and features are configured in the workspace root `pubspec.yaml` under
 `hooks.user_defines.cbl`.
 
-## Commits
+## Pull Requests & Commits
 
-Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Scope to
-the package when changes are limited to one, e.g. `feat(cbl): ...`.
+Pull request titles must use
+[conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
+that are understood by Melos. PRs are squash merged, so the PR title becomes the
+commit message that drives release notes and versioning.
+
+Use the format `<type>[optional scope][!]: <description>`, e.g.
+`feat(cbl): ...`, `fix: ...`, or `feat(cbl)!: ...`. Scope to the package when
+changes are limited to one. Because the PR title is the release-driving commit
+message, prefer `!` in the title for breaking changes.
+
+Melos uses the following PR title types for automatic versioning:
+
+- `feat` — minor version bump.
+- `fix`, `bug`, `perf`, `refactor`, `revert`, `docs` — patch version bump.
+- Any of the above with `!` after the type or scope — major version bump.
+
+Other conventional commit types, such as `chore`, `ci`, `test`, `build`, and
+`style`, are valid conventional commits but do not trigger a Melos version bump.
+Use them only when the PR should not cause a package release.
+
+Commits on PR branches do not need to use any specific message format.
 
 ## Pre-Commit Hooks (lefthook)
 


### PR DESCRIPTION
## Summary
- Simplify Dependabot to a single root `pub` updater for the Dart workspace.
- Switch the `pub` strategy to `widen` so updates do not raise published library lower bounds unnecessarily.
- Add a matrix analyzer job that checks both dependency extremes:
  - `dart pub downgrade` for lowest supported versions
  - `dart pub upgrade` for highest resolvable versions
- Wire the new boundary analyzer job into the CI coverage dependency chain.

## Testing
- YAML config validated successfully.
- `actionlint` passed for `.github/workflows/ci.yaml`.
- Boundary dependency analysis passed in local validation for both lowest and highest dependency sets.