### PR TITLE
ci: harden Android E2E diagnostics

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,7 +259,7 @@ jobs:
 
   test-e2e:
     name: E2E tests
-    timeout-minutes: 25
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -169,6 +169,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.52.1.tgz",
       "integrity": "sha512-gA8oJOV1LnQQkDf91iebNnFInHuW0gRPEgLSOQ7EfipCEjYTHm5swm1DlH9H5RaRw4RrHuzHBegnlzc0MAstcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.52.1",
         "@algolia/requester-browser-xhr": "5.52.1",
@@ -307,6 +308,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -2014,6 +2016,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2036,6 +2039,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2145,6 +2149,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2566,6 +2571,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3610,6 +3616,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
       "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.10.1",
         "@docusaurus/logger": "3.10.1",
@@ -4586,6 +4593,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -5058,6 +5066,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -5411,6 +5420,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5752,6 +5762,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5819,6 +5830,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5864,6 +5876,7 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.1.tgz",
       "integrity": "sha512-fHA8+kXTbjagw3jkLiaS7KKrH8qe2DyOsiUhGlN4cdT77PEsfqXZl7ewDk1hsg+pJnPlnE50XtLxjR91iJOpmg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.18.1",
         "@algolia/client-abtesting": "5.52.1",
@@ -6316,6 +6329,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7276,6 +7290,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -8628,6 +8643,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13073,6 +13089,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13617,6 +13634,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -14532,6 +14550,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -15358,6 +15377,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15367,6 +15387,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15422,6 +15443,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -15450,6 +15472,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -17264,7 +17287,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -17345,6 +17369,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17704,6 +17729,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -17903,6 +17929,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/tools/android-emulator.sh
+++ b/tools/android-emulator.sh
@@ -72,6 +72,45 @@ function adbForEmulator() {
     "$ANDROID_HOME/platform-tools/adb" -s "$serialName" "$@"
 }
 
+function runWithTimeout() {
+    local timeoutDuration="$1"
+    shift
+
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "$timeoutDuration" "$@"
+    elif command -v gtimeout >/dev/null 2>&1; then
+        gtimeout "$timeoutDuration" "$@"
+    else
+        "$@"
+    fi
+}
+
+function collectDiagnostic() {
+    local outputFile="$1"
+    local timeoutDuration="$2"
+    shift 2
+
+    {
+        printf 'Command:'
+        printf ' %q' "$@"
+        printf '\n\n'
+    } >"$outputFile"
+
+    if ! runWithTimeout "$timeoutDuration" "$@" >>"$outputFile" 2>&1; then
+        echo >>"$outputFile"
+        echo "Command failed or timed out after $timeoutDuration" >>"$outputFile"
+    fi
+}
+
+function collectAdbDiagnostic() {
+    local outputFile="$1"
+    local timeoutDuration="$2"
+    shift 2
+
+    collectDiagnostic "$outputFile" "$timeoutDuration" \
+        "$ANDROID_HOME/platform-tools/adb" -s "$serialName" "$@"
+}
+
 function waitForBootProperty() {
     local property="$1"
     local expected="$2"
@@ -82,7 +121,9 @@ function waitForBootProperty() {
 
     while [[ $elapsed -lt $timeoutSeconds ]]; do
         local value
-        value="$(adbForEmulator shell getprop "$property" 2>/dev/null | tr -d '\r')"
+        value="$(runWithTimeout 10s \
+            "$ANDROID_HOME/platform-tools/adb" -s "$serialName" shell getprop "$property" \
+            2>/dev/null | tr -d '\r' || true)"
 
         if [[ "$value" == "$expected" ]]; then
             echo "$property is $expected"
@@ -104,7 +145,9 @@ function waitForPackageManager() {
     echo "Waiting for Android package manager..."
 
     while [[ $elapsed -lt $timeoutSeconds ]]; do
-        if adbForEmulator shell cmd package list packages >/dev/null 2>&1; then
+        if runWithTimeout 10s \
+            "$ANDROID_HOME/platform-tools/adb" -s "$serialName" shell cmd package list packages \
+            >/dev/null 2>&1; then
             echo "Android package manager is ready"
             return 0
         fi
@@ -119,11 +162,13 @@ function waitForPackageManager() {
 
 function waitForEmulatorReady() {
     echo "Waiting for emulator to become ready..."
-    adbForEmulator wait-for-device
+    runWithTimeout 180s "$ANDROID_HOME/platform-tools/adb" -s "$serialName" wait-for-device
     waitForBootProperty sys.boot_completed 1 180
     waitForBootProperty dev.bootcomplete 1 180
     waitForPackageManager 180
-    adbForEmulator shell input keyevent 82 >/dev/null 2>&1 || true
+    runWithTimeout 10s \
+        "$ANDROID_HOME/platform-tools/adb" -s "$serialName" shell input keyevent 82 \
+        >/dev/null 2>&1 || true
     "$ANDROID_HOME/platform-tools/adb" devices -l
     echo "Emulator is ready"
 }
@@ -205,7 +250,8 @@ function setupReversePort() {
     requireOption -p PORT "$port"
 
     echo "Setting up reverse socket connect for port $port"
-    adbForEmulator reverse "tcp:$1" "tcp:$1"
+    runWithTimeout 10s \
+        "$ANDROID_HOME/platform-tools/adb" -s "$serialName" reverse "tcp:$port" "tcp:$port"
 }
 
 function diagnostics() {
@@ -226,11 +272,46 @@ function diagnostics() {
 
     mkdir -p "$outputDirectory"
 
-    "$ANDROID_HOME/platform-tools/adb" devices -l >"$outputDirectory/adb-devices.txt" 2>&1 || true
-    adbForEmulator shell getprop >"$outputDirectory/getprop.txt" 2>&1 || true
-    adbForEmulator shell dumpsys activity processes >"$outputDirectory/dumpsys-activity-processes.txt" 2>&1 || true
-    adbForEmulator shell dumpsys package "$appBundleId" >"$outputDirectory/dumpsys-package.txt" 2>&1 || true
-    adbForEmulator logcat -d -v threadtime >"$outputDirectory/logcat.txt" 2>&1 || true
+    collectDiagnostic "$outputDirectory/adb-version.txt" 10s \
+        "$ANDROID_HOME/platform-tools/adb" version
+    collectDiagnostic "$outputDirectory/adb-server-status.txt" 10s \
+        "$ANDROID_HOME/platform-tools/adb" server-status
+    collectDiagnostic "$outputDirectory/adb-devices.txt" 10s \
+        "$ANDROID_HOME/platform-tools/adb" devices -l
+    collectDiagnostic "$outputDirectory/emulator-version.txt" 10s \
+        "$ANDROID_HOME/emulator/emulator" -version
+    collectDiagnostic "$outputDirectory/emulator-accel-check.txt" 10s \
+        "$ANDROID_HOME/emulator/emulator" -accel-check
+    collectDiagnostic "$outputDirectory/kvm-device.txt" 10s \
+        ls -l /dev/kvm
+    collectAdbDiagnostic "$outputDirectory/adb-get-state.txt" 10s \
+        get-state
+    collectAdbDiagnostic "$outputDirectory/getprop.txt" 20s \
+        shell getprop
+    collectAdbDiagnostic "$outputDirectory/package-list.txt" 15s \
+        shell cmd package list packages -f
+    collectAdbDiagnostic "$outputDirectory/dumpsys-package-app.txt" 20s \
+        shell dumpsys package "$appBundleId"
+    collectAdbDiagnostic "$outputDirectory/dumpsys-package-manager.txt" 20s \
+        shell dumpsys package
+    collectAdbDiagnostic "$outputDirectory/dumpsys-activity-processes.txt" 20s \
+        shell dumpsys activity processes
+    collectAdbDiagnostic "$outputDirectory/dumpsys-activity-top.txt" 15s \
+        shell dumpsys activity top
+    collectAdbDiagnostic "$outputDirectory/dumpsys-activity-services.txt" 15s \
+        shell dumpsys activity services
+    collectAdbDiagnostic "$outputDirectory/ps.txt" 10s \
+        shell ps
+    collectAdbDiagnostic "$outputDirectory/top.txt" 10s \
+        shell top -b -n 1
+    collectAdbDiagnostic "$outputDirectory/disk.txt" 10s \
+        shell df
+    collectAdbDiagnostic "$outputDirectory/logcat-main.txt" 25s \
+        logcat -d -v threadtime
+    collectAdbDiagnostic "$outputDirectory/logcat-events.txt" 25s \
+        logcat -b events -d -v threadtime
+    collectAdbDiagnostic "$outputDirectory/dmesg.txt" 10s \
+        shell dmesg
 
     if [[ -f ./emulator-logs.txt ]]; then
         cp -a ./emulator-logs.txt "$outputDirectory/"

--- a/tools/android-emulator.sh
+++ b/tools/android-emulator.sh
@@ -22,7 +22,7 @@ fi
 emulatorName="cbl-dart"
 emulatorPort=5554
 serialName="emulator-$emulatorPort"
-appBundleId="com.terwesten.gabriel.cbl_e2e_tests_flutter"
+androidTestAppId="com.terwesten.gabriel.cbl_e2e_tests_flutter"
 
 # === Usage ===================================================================
 
@@ -291,7 +291,7 @@ function diagnostics() {
     collectAdbDiagnostic "$outputDirectory/package-list.txt" 15s \
         shell cmd package list packages -f
     collectAdbDiagnostic "$outputDirectory/dumpsys-package-app.txt" 20s \
-        shell dumpsys package "$appBundleId"
+        shell dumpsys package "$androidTestAppId"
     collectAdbDiagnostic "$outputDirectory/dumpsys-package-manager.txt" 20s \
         shell dumpsys package
     collectAdbDiagnostic "$outputDirectory/dumpsys-activity-processes.txt" 20s \
@@ -346,8 +346,8 @@ function bugreport() {
 }
 
 function copyAppData() {
-    adbForEmulator shell "run-as $appBundleId cp -r /data/data/$appBundleId /mnt/sdcard"
-    adbForEmulator pull "/mnt/sdcard/$appBundleId" "appData"
+    adbForEmulator shell "run-as $androidTestAppId cp -r /data/data/$androidTestAppId /mnt/sdcard"
+    adbForEmulator pull "/mnt/sdcard/$androidTestAppId" "appData"
 }
 
 # === Parse command ===========================================================

--- a/tools/ci-steps.sh
+++ b/tools/ci-steps.sh
@@ -41,6 +41,7 @@ targetOs="$TARGET_OS"
 testPackage="$TEST_PACKAGE"
 testPackageDir="packages/$testPackage"
 testAppBundleId="com.terwesten.gabriel.cblE2eTestsFlutter"
+androidTestAppBundleId="com.terwesten.gabriel.cbl_e2e_tests_flutter"
 iosVersion="18-6"
 iosDevice="iPhone 16"
 androidVersion="27"
@@ -109,7 +110,9 @@ function startVirtualDevices() {
         ./tools/apple-simulator.sh start -o "iOS-$iosVersion" -d "$iosDevice"
         ;;
     Android)
+        _printAndroidHostDiagnostics
         ./tools/android-emulator.sh createAndStart -a "$androidVersion" -d "$androidDevice"
+        _resetAndroidAdbServer
         ./tools/android-emulator.sh setupReversePort 4984
         ./tools/android-emulator.sh setupReversePort 4985
         ;;
@@ -177,11 +180,82 @@ function _printAndroidState() {
     fi
 
     echo "=== Android device state ==="
-    "$ANDROID_HOME/platform-tools/adb" devices -l 2>&1 || true
-    "$ANDROID_HOME/platform-tools/adb" -s "emulator-5554" shell getprop sys.boot_completed 2>&1 || true
-    "$ANDROID_HOME/platform-tools/adb" -s "emulator-5554" shell getprop dev.bootcomplete 2>&1 || true
-    "$ANDROID_HOME/platform-tools/adb" -s "emulator-5554" shell cmd package list packages "$testAppBundleId" 2>&1 || true
+    _runAndroidProbe "adb devices" 10s "$ANDROID_HOME/platform-tools/adb" devices -l
+    _runAndroidProbe "adb get-state" 10s "$ANDROID_HOME/platform-tools/adb" -s "emulator-5554" get-state
+    _runAndroidShellProbe "sys.boot_completed" 10s getprop sys.boot_completed
+    _runAndroidShellProbe "dev.bootcomplete" 10s getprop dev.bootcomplete
+    _runAndroidShellProbe "package manager ping" 10s cmd package list packages "$androidTestAppBundleId"
     echo "=== End Android device state ==="
+}
+
+function _runWithTimeout() {
+    local timeoutDuration="$1"
+    shift
+
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "$timeoutDuration" "$@"
+    elif command -v gtimeout >/dev/null 2>&1; then
+        gtimeout "$timeoutDuration" "$@"
+    else
+        "$@"
+    fi
+}
+
+function _runAndroidProbe() {
+    local label="$1"
+    local timeoutDuration="$2"
+    shift 2
+
+    echo "--- $label ---"
+    if ! _runWithTimeout "$timeoutDuration" "$@" 2>&1; then
+        echo "$label failed or timed out after $timeoutDuration"
+    fi
+}
+
+function _runAndroidShellProbe() {
+    local label="$1"
+    local timeoutDuration="$2"
+    shift 2
+
+    _runAndroidProbe "$label" "$timeoutDuration" \
+        "$ANDROID_HOME/platform-tools/adb" -s "emulator-5554" shell "$@"
+}
+
+function _printAndroidHostDiagnostics() {
+    if [[ "$targetOs" != "Android" || -z "${ANDROID_HOME:-}" ]]; then
+        return 0
+    fi
+
+    local adb="$ANDROID_HOME/platform-tools/adb"
+    local emulator="$ANDROID_HOME/emulator/emulator"
+
+    echo "=== Android host diagnostics ==="
+    _runAndroidProbe "uname" 10s uname -a
+    _runAndroidProbe "cpu" 10s sh -c 'nproc; lscpu | sed -n "1,30p"'
+    _runAndroidProbe "memory" 10s free -m
+    _runAndroidProbe "kvm device" 10s ls -l /dev/kvm
+    _runAndroidProbe "adb version" 10s "$adb" version
+    _runAndroidProbe "adb server-status" 10s "$adb" server-status
+    if [ -x "$emulator" ]; then
+        _runAndroidProbe "emulator version" 10s "$emulator" -version
+        _runAndroidProbe "emulator accel check" 10s "$emulator" -accel-check
+    fi
+    echo "=== End Android host diagnostics ==="
+}
+
+function _resetAndroidAdbServer() {
+    if [[ "$targetOs" != "Android" || -z "${ANDROID_HOME:-}" ]]; then
+        return 0
+    fi
+
+    local adb="$ANDROID_HOME/platform-tools/adb"
+
+    echo "=== Resetting Android ADB server ==="
+    _runAndroidProbe "adb kill-server" 10s "$adb" kill-server
+    _runAndroidProbe "adb start-server" 10s "$adb" start-server
+    _runAndroidProbe "adb wait-for-device after reset" 60s "$adb" -s "emulator-5554" wait-for-device
+    _runAndroidProbe "adb devices after reset" 20s "$adb" devices -l
+    echo "=== End Android ADB server reset ==="
 }
 
 function _printAndroidDriveHeartbeat() {
@@ -192,14 +266,16 @@ function _printAndroidDriveHeartbeat() {
     local adb="$ANDROID_HOME/platform-tools/adb"
 
     echo "=== Android flutter drive heartbeat $(date -u '+%Y-%m-%dT%H:%M:%SZ') ==="
-    "$adb" devices -l 2>&1 || true
-    "$adb" -s "emulator-5554" get-state 2>&1 || true
-    "$adb" -s "emulator-5554" shell getprop sys.boot_completed 2>&1 || true
-    "$adb" -s "emulator-5554" shell getprop dev.bootcomplete 2>&1 || true
-    "$adb" -s "emulator-5554" shell pidof "$testAppBundleId" 2>&1 || true
-    "$adb" -s "emulator-5554" shell cmd package list packages "$testAppBundleId" 2>&1 || true
-    "$adb" -s "emulator-5554" shell dumpsys activity top 2>&1 | head -n 80 || true
-    "$adb" -s "emulator-5554" logcat -d -t 120 2>&1 || true
+    _runAndroidProbe "adb devices" 10s "$adb" devices -l
+    _runAndroidProbe "adb get-state" 10s "$adb" -s "emulator-5554" get-state
+    _runAndroidShellProbe "sys.boot_completed" 10s getprop sys.boot_completed
+    _runAndroidShellProbe "dev.bootcomplete" 10s getprop dev.bootcomplete
+    _runAndroidShellProbe "package manager ping" 10s cmd package list packages "$androidTestAppBundleId"
+    _runAndroidShellProbe "app process" 10s pidof "$androidTestAppBundleId"
+    _runAndroidShellProbe "activity top" 10s dumpsys activity top
+    _runAndroidShellProbe "package state" 10s dumpsys package "$androidTestAppBundleId"
+    _runAndroidProbe "recent logcat" 15s "$adb" -s "emulator-5554" logcat -d -t 160 -v threadtime
+    _runAndroidProbe "adb server sockets" 10s ss -tanp
     pgrep -af 'flutter|adb|gradle|java|qemu' || true
     echo "=== End Android flutter drive heartbeat ==="
 }
@@ -474,7 +550,13 @@ function runE2ETests() {
         if [ "$didExplicitBuild" = true ]; then noBuildFlag="--no-build"; fi
         _printAndroidState
         echo "=== Running Flutter drive for $targetOs ==="
-        _runFlutterDrive "$driveVerboseFlag"
+        local driveStatus=0
+        _runFlutterDrive "$driveVerboseFlag" || driveStatus=$?
+        if [ "$driveStatus" -ne 0 ]; then
+            echo "Flutter drive failed with exit code $driveStatus"
+            _printAndroidDriveHeartbeat
+            return "$driveStatus"
+        fi
         echo "=== Finished Flutter drive for $targetOs ==="
         ;;
     esac
@@ -527,7 +609,9 @@ function _collectCrashReportsLinuxFlutter() {
 }
 
 function _isAndroidEmulatorReachable() {
-    "$ANDROID_HOME/platform-tools/adb" -s "emulator-5554" get-state 2>/dev/null | grep -q "device"
+    local adbState
+    adbState="$(_runWithTimeout 10s "$ANDROID_HOME/platform-tools/adb" -s "emulator-5554" get-state 2>/dev/null || true)"
+    [[ "$adbState" == "device" ]]
 }
 
 function _collectCrashReportsAndroid() {
@@ -536,13 +620,8 @@ function _collectCrashReportsAndroid() {
         return 0
     fi
 
-    if command -v timeout >/dev/null 2>&1; then
-        timeout 90s ./tools/android-emulator.sh bugreport -o "$testResultsDir" || \
-            echo "Android bugreport collection failed or timed out"
-    else
-        ./tools/android-emulator.sh bugreport -o "$testResultsDir" || \
-            echo "Android bugreport collection failed"
-    fi
+    _runWithTimeout 90s ./tools/android-emulator.sh bugreport -o "$testResultsDir" || \
+        echo "Android bugreport collection failed or timed out"
 }
 
 function _collectCblLogsStandalone() {
@@ -601,7 +680,7 @@ function _collectCblLogsAndroid() {
         echo "Android emulator is not reachable, skipping app data collection"
         return 0
     fi
-    ./tools/android-emulator.sh copyAppData || {
+    _runWithTimeout 45s ./tools/android-emulator.sh copyAppData || {
         echo "Android app data collection failed"
         return 0
     }
@@ -616,8 +695,32 @@ function _collectAndroidDiagnostics() {
     mkdir -p "$outputDir"
 
     if [[ -n "${ANDROID_HOME:-}" ]]; then
-        "$ANDROID_HOME/platform-tools/adb" devices -l >"$outputDir/adb-devices.txt" 2>&1 || true
+        local adb="$ANDROID_HOME/platform-tools/adb"
+        local emulator="$ANDROID_HOME/emulator/emulator"
+
+        _runWithTimeout 10s "$adb" version >"$outputDir/adb-version.txt" 2>&1 || \
+            echo "adb version failed or timed out" >>"$outputDir/adb-version.txt"
+        _runWithTimeout 10s "$adb" server-status >"$outputDir/adb-server-status.txt" 2>&1 || \
+            echo "adb server-status failed or timed out" >>"$outputDir/adb-server-status.txt"
+        _runWithTimeout 10s "$adb" devices -l >"$outputDir/adb-devices.txt" 2>&1 || \
+            echo "adb devices failed or timed out" >>"$outputDir/adb-devices.txt"
+
+        if [ -x "$emulator" ]; then
+            _runWithTimeout 10s "$emulator" -version >"$outputDir/emulator-version.txt" 2>&1 || \
+                echo "emulator -version failed or timed out" >>"$outputDir/emulator-version.txt"
+            _runWithTimeout 10s "$emulator" -accel-check >"$outputDir/emulator-accel-check.txt" 2>&1 || \
+                echo "emulator -accel-check failed or timed out" >>"$outputDir/emulator-accel-check.txt"
+        fi
     fi
+
+    ps -ef >"$outputDir/host-processes.txt" 2>&1 || true
+    uname -a >"$outputDir/host-uname.txt" 2>&1 || true
+    nproc >"$outputDir/host-cpu-count.txt" 2>&1 || true
+    lscpu >"$outputDir/host-cpu.txt" 2>&1 || true
+    ls -l /dev/kvm >"$outputDir/host-kvm.txt" 2>&1 || true
+    df -h >"$outputDir/host-disk.txt" 2>&1 || true
+    free -m >"$outputDir/host-memory.txt" 2>&1 || true
+    ss -tanp >"$outputDir/host-sockets.txt" 2>&1 || true
 
     if ! _isAndroidEmulatorReachable; then
         echo "Android emulator is not reachable, skipping emulator diagnostics"

--- a/tools/ci-steps.sh
+++ b/tools/ci-steps.sh
@@ -40,8 +40,8 @@ embedder="$EMBEDDER"
 targetOs="$TARGET_OS"
 testPackage="$TEST_PACKAGE"
 testPackageDir="packages/$testPackage"
-testAppBundleId="com.terwesten.gabriel.cblE2eTestsFlutter"
-androidTestAppBundleId="com.terwesten.gabriel.cbl_e2e_tests_flutter"
+appleTestAppBundleId="com.terwesten.gabriel.cblE2eTestsFlutter"
+androidTestAppId="com.terwesten.gabriel.cbl_e2e_tests_flutter"
 iosVersion="18-6"
 iosDevice="iPhone 16"
 androidVersion="27"
@@ -184,7 +184,7 @@ function _printAndroidState() {
     _runAndroidProbe "adb get-state" 10s "$ANDROID_HOME/platform-tools/adb" -s "emulator-5554" get-state
     _runAndroidShellProbe "sys.boot_completed" 10s getprop sys.boot_completed
     _runAndroidShellProbe "dev.bootcomplete" 10s getprop dev.bootcomplete
-    _runAndroidShellProbe "package manager ping" 10s cmd package list packages "$androidTestAppBundleId"
+    _runAndroidShellProbe "package manager ping" 10s cmd package list packages "$androidTestAppId"
     echo "=== End Android device state ==="
 }
 
@@ -231,9 +231,27 @@ function _printAndroidHostDiagnostics() {
 
     echo "=== Android host diagnostics ==="
     _runAndroidProbe "uname" 10s uname -a
-    _runAndroidProbe "cpu" 10s sh -c 'nproc; lscpu | sed -n "1,30p"'
-    _runAndroidProbe "memory" 10s free -m
-    _runAndroidProbe "kvm device" 10s ls -l /dev/kvm
+    if command -v nproc >/dev/null 2>&1; then
+        _runAndroidProbe "cpu count" 10s nproc
+    elif command -v sysctl >/dev/null 2>&1; then
+        _runAndroidProbe "cpu count" 10s sysctl -n hw.ncpu
+    fi
+    if command -v lscpu >/dev/null 2>&1; then
+        _runAndroidProbe "cpu" 10s sh -c 'lscpu | sed -n "1,30p"'
+    elif command -v sysctl >/dev/null 2>&1; then
+        _runAndroidProbe "cpu" 10s sh -c 'sysctl -n machdep.cpu.brand_string 2>/dev/null; sysctl hw.physicalcpu hw.logicalcpu 2>/dev/null'
+    fi
+    if command -v free >/dev/null 2>&1; then
+        _runAndroidProbe "memory" 10s free -m
+    elif command -v vm_stat >/dev/null 2>&1; then
+        _runAndroidProbe "memory" 10s vm_stat
+    fi
+    echo "--- kvm device ---"
+    if [ -e /dev/kvm ]; then
+        ls -l /dev/kvm 2>&1 || true
+    else
+        echo "/dev/kvm not present"
+    fi
     _runAndroidProbe "adb version" 10s "$adb" version
     _runAndroidProbe "adb server-status" 10s "$adb" server-status
     if [ -x "$emulator" ]; then
@@ -270,10 +288,10 @@ function _printAndroidDriveHeartbeat() {
     _runAndroidProbe "adb get-state" 10s "$adb" -s "emulator-5554" get-state
     _runAndroidShellProbe "sys.boot_completed" 10s getprop sys.boot_completed
     _runAndroidShellProbe "dev.bootcomplete" 10s getprop dev.bootcomplete
-    _runAndroidShellProbe "package manager ping" 10s cmd package list packages "$androidTestAppBundleId"
-    _runAndroidShellProbe "app process" 10s pidof "$androidTestAppBundleId"
+    _runAndroidShellProbe "package manager ping" 10s cmd package list packages "$androidTestAppId"
+    _runAndroidShellProbe "app process" 10s pidof "$androidTestAppId"
     _runAndroidShellProbe "activity top" 10s dumpsys activity top
-    _runAndroidShellProbe "package state" 10s dumpsys package "$androidTestAppBundleId"
+    _runAndroidShellProbe "package state" 10s dumpsys package "$androidTestAppId"
     _runAndroidProbe "recent logcat" 15s "$adb" -s "emulator-5554" logcat -d -t 160 -v threadtime
     _runAndroidProbe "adb server sockets" 10s ss -tanp
     pgrep -af 'flutter|adb|gradle|java|qemu' || true
@@ -521,7 +539,7 @@ function runE2ETests() {
                         xcrun simctl install "$simId" "$appBundle" 2>&1 || true
 
                         echo "--- Test-launching app ---"
-                        xcrun simctl launch --terminate-running-process "$simId" "$testAppBundleId" 2>&1 || true
+                        xcrun simctl launch --terminate-running-process "$simId" "$appleTestAppBundleId" 2>&1 || true
                         sleep 5
 
                         echo "--- Checking if app process is alive ---"
@@ -531,7 +549,7 @@ function runE2ETests() {
                         find ~/Library/Logs/DiagnosticReports -name "Runner*" -newer "$appBundle" 2>/dev/null || echo "No crash logs"
 
                         echo "--- Terminate pre-launch ---"
-                        xcrun simctl terminate "$simId" "$testAppBundleId" 2>/dev/null || true
+                        xcrun simctl terminate "$simId" "$appleTestAppBundleId" 2>/dev/null || true
                         sleep 2
                     fi
                 fi
@@ -654,7 +672,7 @@ function _collectCblLogsIosSimulator() {
     ./tools/apple-simulator.sh copyData \
         -o "iOS-$iosVersion" \
         -d "$iosDevice" \
-        -b "$testAppBundleId" \
+        -b "$appleTestAppBundleId" \
         -f "Library/Caches/cbl_flutter/logs" \
         -t "$testResultsDir"
 }
@@ -662,7 +680,7 @@ function _collectCblLogsIosSimulator() {
 function _collectCblLogsMacOS() {
     echo "Collecting Couchbase Lite logs from macOS app"
 
-    local appDataContainer="$HOME/Library/Containers/$testAppBundleId/Data"
+    local appDataContainer="$HOME/Library/Containers/$appleTestAppBundleId/Data"
     local cblLogsDir="$appDataContainer/Library/Caches/cbl_flutter/logs"
 
     if [ ! -e "$cblLogsDir" ]; then
@@ -715,12 +733,35 @@ function _collectAndroidDiagnostics() {
 
     ps -ef >"$outputDir/host-processes.txt" 2>&1 || true
     uname -a >"$outputDir/host-uname.txt" 2>&1 || true
-    nproc >"$outputDir/host-cpu-count.txt" 2>&1 || true
-    lscpu >"$outputDir/host-cpu.txt" 2>&1 || true
-    ls -l /dev/kvm >"$outputDir/host-kvm.txt" 2>&1 || true
+    if command -v nproc >/dev/null 2>&1; then
+        nproc >"$outputDir/host-cpu-count.txt" 2>&1 || true
+    elif command -v sysctl >/dev/null 2>&1; then
+        sysctl -n hw.ncpu >"$outputDir/host-cpu-count.txt" 2>&1 || true
+    fi
+    if command -v lscpu >/dev/null 2>&1; then
+        lscpu >"$outputDir/host-cpu.txt" 2>&1 || true
+    elif command -v sysctl >/dev/null 2>&1; then
+        {
+            sysctl -n machdep.cpu.brand_string 2>/dev/null
+            sysctl hw.physicalcpu hw.logicalcpu 2>/dev/null
+        } >"$outputDir/host-cpu.txt" 2>&1 || true
+    fi
+    if [ -e /dev/kvm ]; then
+        ls -l /dev/kvm >"$outputDir/host-kvm.txt" 2>&1 || true
+    else
+        echo "/dev/kvm not present" >"$outputDir/host-kvm.txt"
+    fi
     df -h >"$outputDir/host-disk.txt" 2>&1 || true
-    free -m >"$outputDir/host-memory.txt" 2>&1 || true
-    ss -tanp >"$outputDir/host-sockets.txt" 2>&1 || true
+    if command -v free >/dev/null 2>&1; then
+        free -m >"$outputDir/host-memory.txt" 2>&1 || true
+    elif command -v vm_stat >/dev/null 2>&1; then
+        vm_stat >"$outputDir/host-memory.txt" 2>&1 || true
+    fi
+    if command -v ss >/dev/null 2>&1; then
+        ss -tanp >"$outputDir/host-sockets.txt" 2>&1 || true
+    elif command -v netstat >/dev/null 2>&1; then
+        netstat -an >"$outputDir/host-sockets.txt" 2>&1 || true
+    fi
 
     if ! _isAndroidEmulatorReachable; then
         echo "Android emulator is not reachable, skipping emulator diagnostics"


### PR DESCRIPTION
## Summary
- Harden Android Flutter E2E diagnostics with bounded ADB/emulator probes, richer host/device artifact collection, emulator version and acceleration checks, and final heartbeat output when `flutter drive` fails.
- Reset the ADB server after emulator startup and wait for the emulator to reconnect before setting reverse ports.
- Split the Apple bundle identifier from the Android application id so iOS/macOS and Android diagnostics target the correct app ids explicitly.
- Make the host diagnostics portable across Linux and macOS while preserving Linux/KVM signal in CI artifacts.
- Give the E2E job more headroom so result collection can still run after a long `Run tests` timeout.
- Includes the docs npm lockfile peer-metadata refresh already present on this branch.

CI is green on `0fe4b808`, including Android Flutter E2E and benchmarks. Local validation covered Bash syntax, ShellCheck, whitespace checks, and stubbed Android setup/result-collection paths.