### PR TITLE
fix(cbl): make build hook a no-op when no code assets are requested

### DIFF
--- a/packages/cbl/hook/build.dart
+++ b/packages/cbl/hook/build.dart
@@ -34,6 +34,15 @@ Future<void> buildHook(BuildInput input, BuildOutputBuilder output) async {
     );
   }
 
+  // The native assets system invokes build hooks for asset types it wants to
+  // discover, which excludes code assets during the initial discovery phase
+  // (e.g. on a cold `flutter run`/`flutter build`). When code assets are not
+  // requested, `input.config.code` is unavailable and accessing it throws. This
+  // hook only produces code assets, so it must be a no-op in that case.
+  if (!input.config.buildCodeAssets) {
+    return;
+  }
+
   final targetOS = input.config.code.targetOS;
   final targetArchitecture = input.config.code.targetArchitecture;
 

--- a/packages/cbl/test/hook/build_test.dart
+++ b/packages/cbl/test/hook/build_test.dart
@@ -73,6 +73,21 @@ void main() {
     );
   });
 
+  test('is a no-op when no code assets are requested', () async {
+    // Regression test for https://github.com/cbl-dart/cbl-dart/issues/973.
+    // The native assets system invokes the build hook during a discovery phase
+    // with an empty `build_asset_types` (so `buildCodeAssets` is false). In
+    // that case `input.config.code` is unavailable, so the hook — which only
+    // produces code assets — must not access it and must produce no assets.
+    final output = await _runBuildHookDirect(
+      targetOS: OS.linux,
+      targetArchitecture: Architecture.x64,
+      setupCodeAssets: false,
+    );
+
+    expect(output.assets.encodedAssets, isEmpty);
+  });
+
   final hostTarget = _hostTarget();
 
   test(
@@ -283,7 +298,7 @@ _HostTarget? _hostTarget() {
   return (os: os, arch: arch);
 }
 
-Future<void> _runBuildHookDirect({
+Future<BuildOutput> _runBuildHookDirect({
   required OS targetOS,
   required Architecture targetArchitecture,
   PackageUserDefines? userDefines,
@@ -291,6 +306,11 @@ Future<void> _runBuildHookDirect({
   int targetIOSVersion = 17,
   int targetMacOSVersion = 13,
   int targetAndroidNdkApi = 30,
+  // When false, the code asset extension is not set up on the build input,
+  // simulating the native assets discovery phase where no code assets are
+  // requested (`build_asset_types` is empty and `input.config.code` is
+  // unavailable).
+  bool setupCodeAssets = true,
 }) async {
   final tempDir = await Directory.systemTemp.createTemp();
 
@@ -314,28 +334,32 @@ Future<void> _runBuildHookDirect({
       ..setupBuildInput()
       ..config.setupBuild(linkingEnabled: false);
 
-    CodeAssetExtension(
-      linkModePreference: LinkModePreference.dynamic,
-      targetArchitecture: targetArchitecture,
-      targetOS: targetOS,
-      iOS: targetOS == OS.iOS
-          ? IOSCodeConfig(
-              targetSdk: targetIOSSdk,
-              targetVersion: targetIOSVersion,
-            )
-          : null,
-      macOS: targetOS == OS.macOS
-          ? MacOSCodeConfig(targetVersion: targetMacOSVersion)
-          : null,
-      android: targetOS == OS.android
-          ? AndroidCodeConfig(targetNdkApi: targetAndroidNdkApi)
-          : null,
-    ).setupBuildInput(inputBuilder);
+    if (setupCodeAssets) {
+      CodeAssetExtension(
+        linkModePreference: LinkModePreference.dynamic,
+        targetArchitecture: targetArchitecture,
+        targetOS: targetOS,
+        iOS: targetOS == OS.iOS
+            ? IOSCodeConfig(
+                targetSdk: targetIOSSdk,
+                targetVersion: targetIOSVersion,
+              )
+            : null,
+        macOS: targetOS == OS.macOS
+            ? MacOSCodeConfig(targetVersion: targetMacOSVersion)
+            : null,
+        android: targetOS == OS.android
+            ? AndroidCodeConfig(targetNdkApi: targetAndroidNdkApi)
+            : null,
+      ).setupBuildInput(inputBuilder);
+    }
 
     final input = inputBuilder.build();
     final output = BuildOutputBuilder();
 
     await hook.buildHook(input, output);
+
+    return output.build();
   } finally {
     tempDir.deleteSync(recursive: true);
   }


### PR DESCRIPTION
## What

Guards the `cbl` build hook so it is a no-op when the native assets system invokes it without requesting code assets.

## Why

Fixes #973. On a cold `flutter run` / `flutter build linux`, the native assets system invokes the build hook in a **discovery phase** with an empty `build_asset_types` (i.e. `input.config.buildCodeAssets == false`). The hook accessed `input.config.code` unconditionally:

```dart
final targetOS = input.config.code.targetOS;
final targetArchitecture = input.config.code.targetArchitecture;
```

During discovery the config JSON is just `{"build_asset_types": [], "linking_enabled": false}` — the `extensions` key is absent — so the `code` getter's `ConfigSyntax.fromJson(json).extensions!.codeAssets!` throws:

```
Null check operator used on a null value
#0  new CodeConfig._fromJson (package:code_assets/src/code_assets/config.dart:52:67)
#1  HookConfigCodeConfig.code (package:code_assets/src/code_assets/config.dart:21:37)
#2  buildHook (.../cbl-4.0.0-dev.8/hook/build.dart:37:33)
```

## How

Added the guard documented by the `hooks` package itself (`if (input.config.buildCodeAssets) { ... }`). Since this hook only ever produces code assets, it now returns early when none are requested:

```dart
if (!input.config.buildCodeAssets) {
  return;
}
```

It is placed **after** the `edition` / `vector_search` validation (which reads only `userDefines`, always available) so genuine misconfiguration still fails fast.

## Tests

Added a regression test in `packages/cbl/test/hook/build_test.dart` that builds a `BuildInput` with no code-asset extension — exactly the discovery-phase scenario — and asserts the hook produces no assets.

- Verified the test reproduces the **exact** stack trace from the issue when the guard is removed, and passes with it.
- `dart analyze` clean on both files.
- The two existing error-path tests plus the new regression test pass (none hit the network). The network integration tests are unaffected — they all set up code assets and take the normal path.