### PR TITLE
ci: fix standalone vm-asan e2e native asset preloading

### DIFF
--- a/tools/ci-steps.sh
+++ b/tools/ci-steps.sh
@@ -142,14 +142,40 @@ function runUnitTests() {
 function _prepareStandaloneSanitizerNativeAssets() {
     requireEnvVar DART_TEST_PLATFORM
 
-    # `dart test -p vm-asan` compiles test suites to native shared libraries,
-    # but that execution path does not currently wire native assets into the
-    # generated process. Build hooks still materialize the native libraries
-    # into `.dart_tool/lib`, so preload them to satisfy `@ffi.DefaultAsset`'s
-    # fallback to process symbol lookup.
-    dart test --help >/dev/null
+    # `dart test -p vm-asan` compiles test suites to native executables, but
+    # that execution path does not currently wire native (code) assets into the
+    # generated process. The build hooks still materialize the native libraries
+    # when a test suite is built, so build them here and preload them to satisfy
+    # `@Native`/`@ffi.DefaultAsset`'s fallback to process symbol lookup.
+    #
+    # Building the native assets requires actually compiling a test suite;
+    # `dart test --help` no longer triggers the build hooks. Compile the
+    # placeholder empty test to run the build hooks without running the real
+    # suite. It exits non-zero because the file contains no tests, so ignore its
+    # exit status — a genuine build failure surfaces below when no libraries are
+    # found.
+    dart test test/empty_test.dart >/dev/null 2>&1 || true
 
-    local nativeLibDir="$PWD/.dart_tool/lib"
+    # With pub workspaces, recent Dart SDKs create the flat native-asset `lib`
+    # directory at the workspace root rather than in the package directory.
+    # Probe both locations and use the first that contains the libraries so the
+    # step keeps working regardless of which layout the SDK uses.
+    local nativeLibDir=""
+    local candidate
+    for candidate in "$workspaceDir/.dart_tool/lib" "$PWD/.dart_tool/lib"; do
+        if find "$candidate" -maxdepth 1 -type f -name 'libcblitedart.so*' \
+            2>/dev/null | grep -q .; then
+            nativeLibDir="$candidate"
+            break
+        fi
+    done
+
+    if [ -z "$nativeLibDir" ]; then
+        echo "No native libraries found to preload in" \
+            "$workspaceDir/.dart_tool/lib or $PWD/.dart_tool/lib"
+        exit 1
+    fi
+
     export LD_LIBRARY_PATH="$nativeLibDir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
     local libcblite


### PR DESCRIPTION
## Summary

The scheduled `CI` workflow on `main` has been failing since ~July 3. The only failing job is **E2E tests (standalone, Ubuntu, vm-asan)**, which fails before running any tests with:

```
find: '.../packages/cbl_e2e_tests_standalone_dart/.dart_tool/lib': No such file or directory
No native libraries found to preload in .../.dart_tool/lib
##[error]Process completed with exit code 1.
```

The same commit (`d796f45`) passed on July 2 and failed from July 3 onward, so the code didn't change — the vm-asan leg runs on the **Dart `main` channel SDK** (`sdk: main`, `flavor: raw`), which auto-updates, and a bleeding-edge SDK update broke the workaround.

## Root cause

`_prepareStandaloneSanitizerNativeAssets` in `tools/ci-steps.sh` preloads the cbl native libraries via `LD_PRELOAD` because `dart test -p vm-asan` compiles the suite to a native executable without wiring code assets into the process, so `@Native`/`@ffi.DefaultAsset` lookups fall back to process symbols. Two assumptions in that workaround broke with the newer SDK:

1. `dart test --help` **no longer triggers the build hooks**, so nothing materialized the native libraries before the preload step.
2. With pub workspaces, the flat native-asset `lib` directory is now created at the **workspace root**, not in the package directory that the step searched.

## Fix

- Trigger the build hooks by compiling the placeholder empty test (`dart test test/empty_test.dart`) instead of `dart test --help`.
- Probe both the workspace-root and package-local `.dart_tool/lib` directories when locating the libraries to preload, so the step keeps working regardless of which layout the SDK uses.
- Fail loudly (unchanged behavior) if no libraries are found after building.

## Verification

Reproduced end-to-end against the current `main` channel SDK (`3.14.0-edge`, 2026-07-08) using a trimmed cbl workspace:

- Confirmed `dart test --help` no longer materializes `.dart_tool/lib`, while a real `dart test` run materializes it at the **workspace root**.
- Reproduced the failure: without the fix, the vm-asan suite fails with `undefined symbol: CBLDart_Initialize`.
- With the fix, the build trigger populates the workspace-root `.dart_tool/lib`, the libraries are found and preloaded, and the vm-asan suite passes (`All tests passed!`).

Only CI tooling changes; no package release is triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vmby6bpG18Nju8ERcarbt

---
_Generated by [Claude Code](https://claude.ai/code/session_012vmby6bpG18Nju8ERcarbt)_